### PR TITLE
Bugfix for building ESMF with external NetCDF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,6 +216,8 @@ if(BUILD_ESMF)
   if(NOT BUILD_NETCDF)
     add_custom_target(netcdf-fortran)
     find_package(NetCDF REQUIRED)
+    # Convert cmake list into space-separated string for ESMF
+    string (REPLACE ";" " " NETCDF_LIBRARIES "${NETCDF_LIBRARIES}")
   endif()
 
   if(NOT BUILD_MPI)


### PR DESCRIPTION
This is a fix for a bug encountered when trying to build ESMF with the NetCDF module on Orion. The environment variable NETCDF_LIBRARIES is returned as a cmake list:
```
-- Found NetCDF: /apps/intel-2020/netcdf-4.7.2/lib/libnetcdff.so;/apps/intel-2020/netcdf-4.7.2/lib/libnetcdff.so;/apps/intel-2020/netcdf-4.7.2/lib/libnetcdff.so;/apps/intel-2020/netcdf-4.7.2/lib/libnetcdff.so;/apps/intel-2020/netcdf-4.7.2/lib/libnetcdf.so
```
The environment variable required for ESMF however must be a space-separated string (similar to how this is set manually when building NetCDF as part of NCEPLIBS-external. Without this bugfix, the call to
```
cd /work/noaa/gmtb/dheinzel/ufs-release-v1/src/NCEPLIBS-external/esmf && /apps/cmake-3.15.4/bin/cmake -E env PATH=/apps/cmake-3.15.4/bin:/apps/jasper-1.900.1/bin:/apps/intel-2020/netcdf-4.7.2/bin:/apps/intel-2020/hdf5-1.10.5/bin:/apps/intel-2020/intel-2020/compilers_and_libraries_2020.0.166/linux/mpi/intel64/libfabric/bin:/apps/intel-2020/intel-2020/compilers_and_libraries_2020.0.166/linux/mpi/intel64/bin:/opt/slurm/bin:/opt/munge/bin:/apps/intel-2020/intel-2020/clck/2019.6/bin/intel64:/apps/intel-2020/intel-2020/compilers_and_libraries_2020.0.166/linux/bin/intel64:/apps/intel-2020/intel-2020/compilers_and_libraries_2020.0.166/linux/bin:/apps/intel-2020/intel-2020/debugger_2020/gdb/intel64/bin:/home/dheinzel/bin:/sbin:/usr/sbin:/bin:/usr/bin:/usr/lib64/qt-3.3/bin:/apps/sbin:/apps/bin:/opt/ibutils/bin ESMF_DIR=/work/noaa/gmtb/dheinzel/ufs-release-v1/src/NCEPLIBS-external/esmf ESMF_COMM=intelmpi ESMF_COMPILER=intel ESMF_NETCDF=1 ESMF_NETCDF_INCLUDE=/apps/intel-2020/netcdf-4.7.2/include ESMF_NETCDF_LIBS=/apps/intel-2020/netcdf-4.7.2/lib/libnetcdff.so /apps/intel-2020/netcdf-4.7.2/lib/libnetcdff.so /apps/intel-2020/netcdf-4.7.2/lib/libnetcdff.so /apps/intel-2020/netcdf-4.7.2/lib/libnetcdff.so /apps/intel-2020/netcdf-4.7.2/lib/libnetcdf.so ESMF_INSTALL_PREFIX=/work/noaa/gmtb/dheinzel/ufs-release-v1/src/NCEPLIBS-external/build/install make
```
produces a segmentation fault and leaves no clue what went wrong.