### PR TITLE
Move version-specific documentation from Wiki into codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,18 @@ This is a compilation of third-party libraries required to build NCEPLIBS and by
 
 It includes the following libraries:
 
-1. CMake: cmake-3.16.3
-2. MPI: openmpi-4.0.2
-3. zlib: zlib-1.2.11
-4. HDF5: hdf5-1.10.4
-5. NetCDF: netcdf-c-4.7.3, netcdf-fortran-4.5.2
-6. libpng: libpng-1.6.35
-7. libjpeg: jpeg-9.1
-8. Jasper: jasper-2.0.16
-9. WGRIB2: wgrib-2.0.8
-10. ESMF: esmf-8.0.0
-
+| Library         | Supported (tested) versions                                |
+|-----------------|------------------------------------------------------------|
+| CMake           | cmake-3.16.3                                               |
+| MPI             | openmpi-4.0.2                                              |
+| zlib            | zlib-1.2.11                                                |
+| HDF5            | hdf5-1.10.4                                                |
+| NetCDF          | netcdf-c-4.7.3, netcdf-fortran-4.5.2                       |
+| libpng          | libpng-1.6.35                                              |
+| libjpeg         | jpeg-9.1                                                   |
+| Jasper          | jasper-2.0.16                                              |
+| WGRIB2          | wgrib-2.0.8                                                |
+| ESMF            | esmf-8.0.0                                                 |
 
 ## Building, Requirements, Troubleshooting, Support
 
@@ -52,7 +53,7 @@ For building NCEPLIBS-external, use `/full_path_to_where_you_installed_cmake/bin
 | MVAPICH2        | 2.3.3                                                      |
 | Open MPI        | 4.0.2                                                      |
 | Intel MPI       | 2018.0.4, 2019.6.154                                       |
-| SGI MPT         | 2.19                       
+| SGI MPT         | 2.19                                                       |
 
 ### Prepare to Build 
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 ## Warning
 
-This documentation as well as the libraries are work in progress and currently undergoing rapid development. Do not expect any of this to work.
+This repository and the documentation are rapidly changing and not ready for general community use.
 
 ## Introduction
 
-This is a compilation of third-party libraries required to build NCEPLIBS and by extension the UFS weather model. 
+This is a compilation of third-party libraries required to build NCEPLIBS and by extension the UFS weather model. For general information about NCEPLIBS-external, NCEPLIBS and the UFS weather model, the user is referred to the [Wiki](https://github.com/NOAA-EMC/NCEPLIBS-external/wiki).
 
 It inclues the following libraries:
 
@@ -24,7 +24,113 @@ It inclues the following libraries:
 
 ## Building, Requirements, Troubleshooting, Support
 
-The user is referred to the [Wiki](https://github.com/NOAA-EMC/NCEPLIBS-external/wiki) for furtherinformation. 
+### Required Software 
+
+1. CMake version 3.12 or newer. If the existing CMake version is too old, you need to install a newer version. The NCEPLIBS-external code contains `cmake-3.16.3` in subdirectory `cmake-src`. To install this version:
+```
+cd ../cmake-src # assuming you are still in the build directory
+./bootstrap --prefix=INSERT_PATH_HERE
+make
+make install
+cd ../build
+rm -fr CMakeCache.txt CMakeFiles
+```
+For building NCEPLIBS-external, use `/full_path_to_where_you_installed_cmake/bin/cmake` instead of just `cmake`.
+
+2. A supported C/C++ and Fortran compiler, see table below. Other versions may work, in particular if close to the versions listed below. If the chosen compiler is not the default compiler on the system, set the environment variables `export CC=...`, `export CXX=...`, `export FC=...`, before invoking `cmake`.
+
+| Compiler vendor | Supported (tested) versions                                |
+|-----------------|------------------------------------------------------------|
+| Intel           | 18.0.3.222, 18.0.5.274, 19.0.2.187, 19.0.5.281             |
+| GNU             | 8.3.0, 9.1.0, 9.2.0                                        |
+
+3. A supported MPI library unless installed as part of NCEPLIBS-external, see table below. Other versions may work, in particular if close to the versions listed below. It is recommended to compile the MPI library with the same compilers used to compile NCEPLIBS-external.
+
+| MPI library     | Supported (tested) versions                                |
+|-----------------|------------------------------------------------------------|
+| MPICH           | 3.3.1, 3.3.2                                               |
+| MVAPICH2        | 2.3.3                                                      |
+| Open MPI        | 4.0.2                                                      |
+| Intel MPI       | 2018.0.4, 2019.6.154                                       |
+| SGI MPT         | 2.19                       
+
+### Prepare to Build 
+
+The following sections provide setup and usage instructions for a range of systems with different level of support. The definitions of the different support levels (e.g. pre-configured, configurable) are on the [Supported Platforms and Compilers](https://github.com/ufs-community/ufs/wiki/Supported-Platforms-and-Compilers) page.
+
+### Setup instructions for configurable systems
+
+Configurable systems are macOS and Linux using the open-source GNU compilers (or a combination of the LLVM clang and GNU gfortran compiler for macOS), and the Intel compilers. Instructions are provided for selected versions of macOS and several Linux distributions/versions. As OS, compiler and library versions evolve over time, the instructions may not reflect the latest versions at all time. They should, however, work if the versions do not differ significantly.
+
+Note that Windows systems and other compilers (e.g. PGI) are not supported at this time.
+
+- Setup instructions for macOS Mojave/Catalina using gcc and gfortran can be found in `doc/README_macos_gccgfortran.txt` in the repository.
+- Setup instructions for macOS Mojave/Catalina using clang and gfortran can be found in `doc/README_macos_clanggfortran.txt` in the repository.
+- Setup instructions for Red Hat Linx 8 using gcc and gfortran can be found in `doc/README_redhat_gnu.txt` in the repository.
+
+### Setup instructions for pre-configured systems
+
+Pre-configured systems do have existing installations of NCEPLIBS-external and NCEPLIBS. Users should not have to build any of these unless new versions of the external libraries or the NCEPLIBS are to be tested. In this case, the following instructions will be useful to repeat the steps the UFS developers have taken. They can also be useful for users trying to install NCEPLIBS-external and NCEPLIBS on other HPC platforms with preinstalled MPI, netCDF, ...
+
+- Installation notes for NOAA RDHPC Hera using icc and ifort: `doc/README_hera_intel.txt`
+- Installation notes for NOAA RDHPC Jet using icc and ifort: `doc/README_jet_intel.txt`
+- Installation notes for NOAA RDHPC Gaea using icc and ifort: `doc/README_gaea_intel.txt`
+- Installation notes for CISL Cheyenne using icc and ifort: `doc/README_cheyenne_intel.txt`
+- Installation notes for CISL Cheyenne using gcc and gfortran: `doc/README_cheyenne_gnu.txt`
+
+### Get and Build the Code
+
+```
+# Replace "master" with the tag that is supposed to be used
+git clone -b master --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+cd NCEPLIBS-external
+mkdir build
+cd build
+cmake -DCMAKE_INSTALL_PREFIX=INSERT_PATH_HERE ..
+make <-jx>
+```
+If `-DCMAKE_INSTALL_PREFIX=` is omitted, the libraries will be installed in directory `install` underneath the `build` directory. The optional argument `<-jx>` speeds up the build process by using `x` parallel compile tasks.
+
+By default, NCEPLIBS-external will build and install all libraries listed above except the optional CMake (see next section when this is needed). This is primarily targeted for users who are setting up their own workstations in order to get a consistent software stack. It is important that the MPI wrappers use the same compiler that is used to compile the other external libraries, the NCEP libraries and any UFS application that depends on those. 
+
+Users working on HPC systems should use the MPI libraries installed by the system administrators for the compiler they want to use. Usually compilers and MPI libraries can be loaded as modules on those systems. If other dependencies such as netCDF are also provided as modules for the target compiler, then these should also be used. In this case, users need to turn off explicitly the build of those libraries as follows:
+
+### Turn Off Specific Libraries
+
+*How to turn off building ...*
+
+1. CMake: not necessary, CMake is installed in a separate step only if the default OS version is too old (see below).
+
+2. MPI: Add `-DBUILD_MPI=OFF` to the cmake flags. If CMake cannot find the MPI library, make sure that the MPI wrappers are in the `PATH` environment variable, and set the environment variable `MPI_ROOT` to the directory where MPI was installed.
+
+3. zlib: zlib will be built as dependency for NetCDF or libpng. If neither of those is built, the zlib build is also turned off.
+
+4. HDF5: will be built as dependency for NetCDF.  If netCDF is not built, the HDF5 build is also turned off.
+
+5. NetCDF: Add `-DBUILD_NETCDF=OFF` to the cmake flags. If CMake cannot find the netCDF/netCDF Fortran library, set the environment variable `NETCDF` to the directory where NetCDF was installed. On some systems, the netCDF-c and netCDF-fortran libraries are installed in separate locations. In this case, set set the environment variable `NETCDF` to the directory where netcdf-c was installed, and `NETCDF_FORTRAN` to the directory where netcdf-fortran was installed.
+
+6. libpng: Add `-DBUILD_PNG=OFF` to the cmake flags. If CMake cannot find the libpng library, set the environment variable `LIBPNG_ROOT` to the directory where libpng was installed.
+
+7. libjpeg: libjpeg will be built as dependency for Jasper. If Jasper is not built, the libjpeg build is also turned off.
+
+8. Jasper: Add `-DBUILD_JASPER=OFF` to the cmake flags. If CMake cannot find the Jasper library, set the environment variable `Jasper_ROOT` to the directory where Jasper was installed (note the case-sensitive name of the environment variable).
+
+9. WGRIB2: Add `-DBUILD_WGRIB2=OFF` to the cmake flags. If CMake cannot find the WGRIB2 Fortran modules or library, set the environment variable `WGRIB2_ROOT` to the directory where WGRIB2 was installed. Note that WGRIB2 installations vary between systems. For the NCEPLIBS build to work, the WGRIB2 Fortran modules are expected in `WGRIB2_ROOT/include` and the WGRIB2 library in `WGRIB2_ROOT/lib`.
+
+10. ESMF: Add `-DBUILD_ESMF=OFF` to the cmake flags and set the environment variable `ESMFMKFILE` to point to the file `esmf.mk` of the ESMF installation.
+
+The above options to turn off selected components can also be used by advanced users who already have parts of the software stack installed for the UFS.
+
+### Troubleshooting
+
+1. The cmake step reports an error that it cannot detect the MPI type. Only the MPI libraries listed above have been preconfigured for ESMF. Other libraries can be used by setting `-DMPITYPE=...` in the cmake call, provided that ESMF supports this library (currently supported by ESMF: mpi, mpt, mpich, mpich2, mpich3, mvapich2, intelmpi, lam - see ESMF documentation for details).
+
+2. The build fails because of undefined symbols in any of the libraries. The most likely reason for this error is that cmake found a different version of the library on the system, for example installed by the Linux package manager or homebrew on macOS. While there is no single solution for this problem, the following options have been used successfully:
+    - Remove the existing library, if possible (often it is not, because other software on the system depends on it)
+    - Take the existing library out of the `PATH` and `LD_LIBRARY_PATH`, if possible (not always, because other software installed in the same location, may be needed). On HPC systems, this often means unloading a specific module.
+    - Look inside NCEPLIBS-external's top-level `CMakeLists.txt` if the offending library is one of the build targets, and if yes, turn it off.
+    - If the offending library is a prerequisite for a build target (i.e. HDF5 is a prerequisite for NetCDF) and the build target itself is already installed on the system, try to turn off the build target (e.g. `option(BUILD_NETCDF "Build NetCDF?" OFF)`)
+    - If the offending library is a prerequisite for a build target (i.e. HDF5 is a prerequisite for NetCDF) and the build target itself is _not_ installed on the system, you need to install the build target using the same method you used for installing the offending library and turn it off in `CMakeLists.txt`.
 
 ## Disclaimer
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository and the documentation are rapidly changing and not ready for gen
 
 This is a compilation of third-party libraries required to build NCEPLIBS and by extension the UFS weather model. For general information about NCEPLIBS-external, NCEPLIBS and the UFS weather model, the user is referred to the [Wiki](https://github.com/NOAA-EMC/NCEPLIBS-external/wiki).
 
-It inclues the following libraries:
+It includes the following libraries:
 
 1. CMake: cmake-3.16.3
 2. MPI: openmpi-4.0.2

--- a/doc/README_cheyenne_gnu.txt
+++ b/doc/README_cheyenne_gnu.txt
@@ -1,0 +1,55 @@
+Setup instructions for CISL Cheyenne using GNU-8.3.0
+
+module purge
+module load ncarenv/1.3
+module load gnu/8.3.0
+module load ncarcompilers/0.5.0
+module load netcdf/4.7.3
+module load mpt/2.19
+module load cmake/3.16.4
+module li
+
+> Currently Loaded Modules:
+>  1) ncarenv/1.3   2) gnu/8.3.0   3) ncarcompilers/0.5.0   4) netcdf/4.7.3   5) mpt/2.19   6) cmake/3.16.4
+
+export CC=mpicc
+export FC=mpif90
+export CXX=mpicxx
+
+mkdir -p /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta01/gnu-8.3.0/mpt-2.19/src
+cd /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta01/gnu-8.3.0/mpt-2.19/src
+
+git clone -b ufs-v1.0.0.beta01 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+cd NCEPLIBS-external
+mkdir build && cd build
+cmake -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta01/gnu-8.3.0/mpt-2.19 .. 2>&1 | tee log.cmake
+make VERBOSE=1 -j2 2>&1 | tee log.make
+
+cd /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta01/gnu-8.3.0/mpt-2.19/src
+git clone -b ufs-v1.0.0.beta01 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+cd NCEPLIBS
+mkdir build && cd build
+cmake -DEXTERNAL_LIBS_DIR=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta01/gnu-8.3.0/mpt-2.19 -DCMAKE_INSTALL_PREFIX=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta01/gnu-8.3.0/mpt-2.19 .. 2>&1 | tee log.cmake
+make VERBOSE=1 -j2 2>&1 | tee log.make
+make install
+
+
+How to build the model with those libraries installed:
+
+module purge
+module load ncarenv/1.3
+module load gnu/8.3.0
+module load ncarcompilers/0.5.0
+module load netcdf/4.7.3
+module load mpt/2.19
+module load cmake/3.16.4
+
+export CC=mpicc
+export FC=mpif90
+export CXX=mpicxx
+
+module use -a /glade/p/ral/jntp/GMTB/tools/modulefiles/gnu-8.3.0/mpt-2.19
+module load  NCEPlibs/1.0.0beta01
+
+export CMAKE_Platform=cheyenne.gnu
+./build.sh 2>&1 | tee build.log

--- a/doc/README_cheyenne_intel.txt
+++ b/doc/README_cheyenne_intel.txt
@@ -1,0 +1,55 @@
+Setup instructions for CISL Cheyenne using Intel-18.0.5
+
+module purge
+module load ncarenv/1.3
+module load intel/19.0.5
+module load ncarcompilers/0.5.0
+module load netcdf/4.7.3
+module load mpt/2.19
+module load cmake/3.16.4
+module li
+
+> Currently Loaded Modules:
+>  1) ncarenv/1.3   2) intel/19.0.5   3) ncarcompilers/0.5.0   4) mpt/2.19   5) netcdf/4.7.3   6) cmake/3.16.4
+
+export CC=mpicc
+export FC=mpif90
+export CXX=mpicxx
+
+mkdir -p /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta01/intel-19.0.5/mpt-2.19/src
+cd /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta01/intel-19.0.5/mpt-2.19/src
+
+git clone -b ufs-v1.0.0.beta01 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+cd NCEPLIBS-external
+mkdir build && cd build
+cmake -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta01/intel-19.0.5/mpt-2.19 .. 2>&1 | tee log.cmake
+make VERBOSE=1 -j2 2>&1 | tee log.make
+
+cd /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta01/intel-19.0.5/mpt-2.19/src/
+git clone -b ufs-v1.0.0.beta01 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+cd NCEPLIBS
+mkdir build && cd build
+cmake -DEXTERNAL_LIBS_DIR=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta01/intel-19.0.5/mpt-2.19 -DCMAKE_INSTALL_PREFIX=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta01/intel-19.0.5/mpt-2.19 .. 2>&1 | tee log.cmake
+make VERBOSE=1 -j2 2>&1 | tee log.make
+make install
+
+
+How to build the model with those libraries installed:
+
+module purge
+module load ncarenv/1.3
+module load intel/19.0.5
+module load ncarcompilers/0.5.0
+module load netcdf/4.7.3
+module load mpt/2.19
+module load cmake/3.16.4
+
+export CC=mpicc
+export FC=mpif90
+export CXX=mpicxx
+
+module use -a /glade/p/ral/jntp/GMTB/tools/modulefiles/intel-19.0.5/mpt-2.19
+module load  NCEPlibs/1.0.0beta01
+
+export CMAKE_Platform=cheyenne.intel
+./build.sh 2>&1 | tee build.log

--- a/doc/README_gaea_intel.txt
+++ b/doc/README_gaea_intel.txt
@@ -1,0 +1,62 @@
+Setup instructions for NOAA RDHPC Gaea using Cray Intel-18.0.3.222
+
+module load intel/18.0.3.222
+module load cray-netcdf/4.4.0
+module use -a /lustre/f2/pdata/esrl/gsd/ufs/modules/modulefiles/generic
+module load cmake/3.16.4
+module li
+
+> Currently Loaded Modulefiles:
+>   1) modules/3.2.10.5                                6) cray-libsci/16.06.1                            11) gni-headers/5.0.12-6.0.6.0_3.26__g527b6e1.ari  16) rca/2.2.18-6.0.6.0_19.14__g2aa4f39.ari         21) CmrsEnv                                        26) hpcrpt/noaa-3
+>   2) eproxy/2.0.22-6.0.6.0_5.1__g1ebe45c.ari         7) udreg/2.3.2-6.0.6.0_15.18__g5196236.ari        12) xpmem/2.2.14-6.0.6.1_5.8__g34333c9.ari         17) atp/2.0.2                                      22) TimeZoneEDT                                    27) cray-netcdf/4.6.1.3
+>   3) intel/18.0.3.222                                8) ugni/6.0.14-6.0.6.0_18.12__g777707d.ari        13) job/2.2.3-6.0.6.0_9.47__g6c4e934.ari           18) PrgEnv-intel/6.0.3                             23) globus_toolkit/6.0.1470089956                  28) cmake/3.16.4
+>   4) craype-network-aries                            9) pmi/5.0.10-1.0000.11050.0.0.ari                14) dvs/2.7_2.2.96-6.0.6.1_10.6__g9b73f30          19) craype-broadwell                               24) globus/6.0.1470089956                          29) cray-netcdf/4.4.0
+>   5) craype/2.5.5                                   10) dmapp/7.1.1-6.0.6.0_51.37__g5a674e0.ari        15) alps/6.6.0-6.0.6.0_35.25__gd0a1ab9.ari         20) cray-mpich/7.4.0                               25) DefApps
+
+# Need to use MPI wrappers in order to find pre-installed Cray MPICH
+export CC=cc
+export FC=ftn
+export CXX=CC
+export HDF5_ROOT=/opt/cray/pe/hdf5/1.8.16/INTEL/15.0
+export MPI_ROOT=/opt/cray/pe/mpt/7.4.0/gni/mpich-intel/15.0
+export NETCDF=$NETCDF_DIR
+
+mkdir -p /lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0.beta01/intel-18.0.3.222/cray-mpich-7.4.0/src
+
+cd /lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0.beta01/intel-18.0.3.222/cray-mpich-7.4.0/src
+# Note: remote access severely limited on gaea; need to do the git clone on a remote system and rsync to gaea
+git clone -b ufs-v1.0.0.beta01 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+cd NCEPLIBS-external
+mkdir build && cd build
+cmake -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DBUILD_JASPER=OFF -DCMAKE_INSTALL_PREFIX=/lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0.beta01/intel-18.0.3.222/cray-mpich-7.4.0 .. 2>&1 | tee log.cmake
+make VERBOSE=1 2>&1 | tee log.make
+# no make install necessary
+
+cd /lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0.beta01/intel-18.0.3.222/cray-mpich-7.4.0/src
+# Note: remote access severely limited on gaea; need to do the git clone on a remote system and rsync to gaea
+git clone -b ufs-v1.0.0.beta01 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+cd NCEPLIBS
+mkdir build && cd build
+cmake -DEXTERNAL_LIBS_DIR=/lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0.beta01/intel-18.0.3.222/cray-mpich-7.4.0 -DCMAKE_INSTALL_PREFIX=/lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0.beta01/intel-18.0.3.222/cray-mpich-7.4.0 -DSTATIC_IS_DEFAULT=ON .. 2>&1 | tee log.cmake
+make VERBOSE=1 2>&1 | tee log.make
+make install VERBOSE=1 2>&1 | tee log.install
+
+
+How to build the model with those libraries installed:
+
+module load intel/18.0.3.222
+module load cray-netcdf/4.4.0
+
+module use -a /lustre/f2/pdata/esrl/gsd/ufs/modules/modulefiles/generic
+module load cmake/3.16.4
+
+module use -a /lustre/f2/pdata/esrl/gsd/ufs/modules/modulefiles/intel-18.0.3.222
+module load NCEPlibs/1.0.0.beta01
+
+export NETCDF=$NETCDF_DIR
+export CMAKE_Platform=gaea.intel
+export CMAKE_C_COMPILER=cc
+export CMAKE_CXX_COMPILER=CC
+export CMAKE_Fortran_COMPILER=ftn
+
+./build.sh 2>&1 | tee build.log

--- a/doc/README_hera_intel.txt
+++ b/doc/README_hera_intel.txt
@@ -1,0 +1,60 @@
+Setup instructions for NOAA RDHPC Hera using Intel-18.0.5.274
+
+module purge
+module load intel/18.0.5.274
+module load impi/2018.0.4
+module load netcdf/4.7.0
+module use -a /scratch1/BMC/gmtb/software/modulefiles/generic
+module load cmake/3.16.3
+module li
+
+> Currently Loaded Modules:
+>  1) intel/18.0.5.274   2) impi/2018.0.4   3) netcdf/4.7.0   4) cmake/3.16.3
+
+# Note: HDF5 is in: /apps/hdf5/1.10.5/intel/18.0.5.274
+# Note: ZLIB and PNG are in: /usr/include, /usr/lib64/
+
+export CC=icc
+export CXX=icpc
+export FC=ifort
+
+export HDF5_ROOT=/apps/hdf5/1.10.5/intel/18.0.5.274
+export PNG_ROOT=/usr
+
+mkdir -p /scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0.beta01/intel-18.0.5.274/impi-2018.0.4/src
+cd /scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0.beta01/intel-18.0.5.274/impi-2018.0.4/src
+
+git clone -b ufs-v1.0.0.beta01 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+cd NCEPLIBS-external
+mkdir build && cd build
+
+# If netCDF is not built, also don't build PNG, because netCDF uses the default (OS) zlib in the search path
+cmake -DBUILD_PNG=OFF -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=/scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0.beta01/intel-18.0.5.274/impi-2018.0.4 .. 2>&1 | tee log.cmake
+make VERBOSE=1 -j8 2>&1 | tee log.make
+
+cd /scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0.beta01/intel-18.0.5.274/impi-2018.0.4/src
+git clone -b ufs-v1.0.0.beta01 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+cd NCEPLIBS
+mkdir build && cd build
+cmake -DEXTERNAL_LIBS_DIR=/scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0.beta01/intel-18.0.5.274/impi-2018.0.4 -DCMAKE_INSTALL_PREFIX=/scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0.beta01/intel-18.0.5.274/impi-2018.0.4 .. 2>&1 | tee log.cmake
+make VERBOSE=1 -j8 2>&1 | tee log.make
+make install
+
+
+How to build the model with those libraries installed:
+
+module load intel/18.0.5.274
+module load impi/2018.0.4
+module load netcdf/4.7.0
+module use -a /scratch1/BMC/gmtb/software/modulefiles/generic
+module load cmake/3.16.3
+
+export CC=icc
+export CXX=icpc
+export FC=ifort
+
+module use -a /scratch1/BMC/gmtb/software/modulefiles/intel-18.0.5.274/impi-2018.0.4
+module load NCEPlibs/1.0.0beta01
+
+export CMAKE_Platform=hera.intel
+./build.sh 2>&1 | tee build.log

--- a/doc/README_jet_intel.txt
+++ b/doc/README_jet_intel.txt
@@ -1,0 +1,61 @@
+Setup instructions for NOAA RDHPC Jet using Intel-18.0.5.274
+
+module purge
+module load intel/18.0.5.274
+module load impi/2018.4.274
+module load netcdf/4.7.0
+module use -a /lfs3/projects/hfv3gfs/GMTB/modulefiles/generic
+module load cmake/3.16.4
+module li
+
+> Currently Loaded Modules:
+>  1) intel/18.0.5.274   2) impi/2018.4.274   3) netcdf/4.7.0   4) cmake/3.16.4
+
+export CC=icc
+export FC=ifort
+export CXX=icpc
+
+# HDF5 is in: /apps/hdf5/1.10.5/intel/18.0.5.274
+# ZLIB and PNG are in: /usr/include, /usr/lib64
+
+export HDF5_ROOT=/apps/hdf5/1.10.5/intel/18.0.5.274
+export PNG_ROOT=/usr
+
+mkdir -p /lfs3/projects/hfv3gfs/GMTB/NCEPlibs-ufs-v1.0.0.beta01/intel-18.0.5.274/impi-2018.4.274/src
+cd /lfs3/projects/hfv3gfs/GMTB/NCEPlibs-ufs-v1.0.0.beta01/intel-18.0.5.274/impi-2018.4.274/src
+
+git clone -b ufs-v1.0.0.beta01 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+cd NCEPLIBS-external
+mkdir build && cd build
+
+# If netCDF is not built, also don't build PNG, because netCDF uses the default (OS) zlib in the search path
+cmake -DBUILD_PNG=OFF -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=/lfs3/projects/hfv3gfs/GMTB/NCEPlibs-ufs-v1.0.0.beta01/intel-18.0.5.274/impi-2018.4.274 .. 2>&1 | tee log.cmake
+make VERBOSE=1 -j8 2>&1 | tee log.make
+
+cd /lfs3/projects/hfv3gfs/GMTB/NCEPlibs-ufs-v1.0.0.beta01/intel-18.0.5.274/impi-2018.4.274/src
+git clone -b ufs-v1.0.0.beta01 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+cd NCEPLIBS
+mkdir build && cd build
+cmake -DEXTERNAL_LIBS_DIR=/lfs3/projects/hfv3gfs/GMTB/NCEPlibs-ufs-v1.0.0.beta01/intel-18.0.5.274/impi-2018.4.274 -DCMAKE_INSTALL_PREFIX=/lfs3/projects/hfv3gfs/GMTB/NCEPlibs-ufs-v1.0.0.beta01/intel-18.0.5.274/impi-2018.4.274 .. 2>&1 | tee log.cmake
+make VERBOSE=1 -j8 2>&1 | tee log.make
+make install
+
+
+How to build the model with those libraries installed:
+
+module purge
+module load intel/18.0.5.274
+module load impi/2018.4.274
+module load netcdf/4.7.0
+module use -a /lfs3/projects/hfv3gfs/GMTB/modulefiles/generic
+module load cmake/3.16.4
+
+export CC=icc
+export FC=ifort
+export CXX=icpc
+
+module use -a /lfs3/projects/hfv3gfs/GMTB/modulefiles/intel-18.0.5.274/impi-2018.4.274
+module load NCEPlibs/1.0.0beta01
+
+export CMAKE_Platform=jet.intel
+./build.sh 2>&1 | tee build.log

--- a/doc/README_macos_clanggfortran.txt
+++ b/doc/README_macos_clanggfortran.txt
@@ -1,0 +1,88 @@
+Setup instructions for macOS Mojave or Catalina using clang-9.0.0 + gfortran-9.2.0
+
+The following instructions were tested on a clean macOS systems (Mojave 1.14.6 and Catalina 10.15.2).
+Homebrew is used to install the LLVM (clang+clang++) and GNU (gcc+gfortran) compilers. Note that the export statements
+are required for the subsequent steps, as well as for building NCEPLIBS-external, NCEPLIBS and UFS applications.
+
+1. Install homebrew, the LLVM/GNU compilers and other utilities
+
+(1) Install homebrew
+/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+
+(1a) Mojave only: Install SDK headers
+open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg
+
+(2) Create directories
+sudo su
+mkdir /usr/local/ufs-release-v1
+chown YOUR_USERNAME:YOUR_GROUPNAME /usr/local/ufs-release-v1
+exit
+cd /usr/local/ufs-release-v1
+mkdir src
+
+(3) Install gcc-9.2.0/gfortran-9.2.0
+
+brew install gcc@9
+
+(4) Install clang-9.0.0/clang++-9.0.0
+
+brew install llvm@9
+
+export CC=clang-9
+export FC=gfortran-9
+export CXX=clang++-9
+
+(5) Install wget-0.20.1
+
+brew install wget
+
+(6) Install cmake-3.16.2
+
+brew install cmake
+
+(7) Install coreutils-8.31 (required later for running the UFS models)
+brew install coreutils
+
+2. Install missing external libraries from NCEPLIBS-external
+
+The user is referred to the top-level README.md for more detailed instructions on how to build
+NCEPLIBS-external and configure it (e.g., how to turn off building certain packages such as MPI etc).
+The default configuration assumes that all dependencies are built and installed: MPI, netCDF, ...
+
+cd /usr/local/ufs-release-v1/src
+git clone -b ufs-v1.0.0.beta01 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+cd NCEPLIBS-external
+mkdir build && cd build
+cmake -DCMAKE_INSTALL_PREFIX=/usr/local/ufs-release-v1 .. 2>&1 | tee log.cmake
+make -j8 2>&1 | tee log.make
+# no make install needed
+
+3. Install NCEPLIBS
+
+The user is referred to the top-level README.md of the NCEPLIBS GitHub repository
+(https://github.com/NOAA-EMC/NCEPLIBS/) for more detailed instructions on how to configure
+and build NCEPLIBS. The default configuration assumes that all dependencies were built
+by NCEPLIBS-external as described above.
+
+cd /usr/local/ufs-release-v1/src
+git clone -b ufs-v1.0.0.beta01 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+cd NCEPLIBS
+mkdir build
+cd build
+cmake -DCMAKE_INSTALL_PREFIX=/usr/local/ufs-release-v1 -DEXTERNAL_LIBS_DIR=/usr/local/ufs-release-v1 .. 2>&1 | tee log.cmake
+make -j8 2>&1 | tee log.make
+make install 2>&1 | tee log.install
+
+4. To build the UFS models, source the shell script created by the NCEPLIBS installation and adjust the stacksize:
+
+export CC=clang-9
+export FC=gfortran-9
+export CXX=clang++-9
+ulimit -S -s unlimited
+. /usr/local/ufs-release-v1/bin/setenv_nceplibs.sh
+export CMAKE_Platform=macosx.gnu
+./build.sh 2>&1 | tee build.log
+
+Note. OpenMP support is currently broken with the clang compiler. The UFS models should detect that
+the clang compiler is used and turn off threading when building the model.
+

--- a/doc/README_macos_clanggfortran.txt
+++ b/doc/README_macos_clanggfortran.txt
@@ -4,6 +4,8 @@ The following instructions were tested on a clean macOS systems (Mojave 1.14.6 a
 Homebrew is used to install the LLVM (clang+clang++) and GNU (gcc+gfortran) compilers. Note that the export statements
 are required for the subsequent steps, as well as for building NCEPLIBS-external, NCEPLIBS and UFS applications.
 
+Note that 16GB of memory are required for running the UFS weather model at C96 resolution.
+
 1. Install homebrew, the LLVM/GNU compilers and other utilities
 
 (1) Install homebrew

--- a/doc/README_macos_gccgfortran.txt
+++ b/doc/README_macos_gccgfortran.txt
@@ -1,0 +1,82 @@
+Setup instructions for macOS Mojave or Catalina using gcc-9.2.0 + gfortran-9.2.0
+
+The following instructions were tested on a clean macOS systems (Mojave 1.14.6 and Catalina 10.15.2).
+Homebrew is used to install the GNU (gcc+gfortran) compilers. Note that the export statements are
+required for the subsequent steps, as well as for building NCEPLIBS-external, NCEPLIBS and UFS applications.
+
+1. Install homebrew, the GNU compilers and other utilities:
+
+(1) Install homebrew
+/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+
+(1a) Mojave only: Install SDK headers
+open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10.14.pkg
+
+(2) Create directories
+sudo su
+mkdir /usr/local/ufs-release-v1
+chown YOUR_USERNAME:YOUR_GROUPNAME /usr/local/ufs-release-v1
+exit
+cd /usr/local/ufs-release-v1
+mkdir src
+
+(3) Install gcc-9.2.0/gfortran-9.2.0
+
+brew install gcc@9
+
+export CC=gcc-9
+export FC=gfortran-9
+export CXX=g++-9
+
+(4) Install wget-0.20.1
+
+brew install wget
+
+(5) Install cmake-3.16.2
+
+brew install cmake
+
+(6) Install coreutils-8.31 (required later for running the UFS models)
+brew install coreutils
+
+2. Install missing external libraries from NCEPLIBS-external
+
+The user is referred to the top-level README.md for more detailed instructions on how to build
+NCEPLIBS-external and configure it (e.g., how to turn off building certain packages such as MPI etc).
+The default configuration assumes that all dependencies are built and installed: MPI, netCDF, ...
+
+cd /usr/local/ufs-release-v1/src
+git clone -b ufs-v1.0.0.beta01 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+cd NCEPLIBS-external
+mkdir build && cd build
+cmake -DCMAKE_INSTALL_PREFIX=/usr/local/ufs-release-v1 .. 2>&1 | tee log.cmake
+make -j8 2>&1 | tee log.make
+# no make install needed
+
+3. Install NCEPLIBS
+
+The user is referred to the top-level README.md of the NCEPLIBS GitHub repository
+(https://github.com/NOAA-EMC/NCEPLIBS/) for more detailed instructions on how to configure
+and build NCEPLIBS. The default configuration assumes that all dependencies were built
+by NCEPLIBS-external as described above.
+
+cd /usr/local/ufs-release-v1/src
+git clone -b ufs-v1.0.0.beta01 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+cd NCEPLIBS
+mkdir build
+cd build
+cmake -DCMAKE_INSTALL_PREFIX=/usr/local/ufs-release-v1 -DEXTERNAL_LIBS_DIR=/usr/local/ufs-release-v1 .. 2>&1 | tee log.cmake
+make -j8 2>&1 | tee log.make
+make install 2>&1 | tee log.install
+
+4. To build the UFS models, source the shell script created by the NCEPLIBS installation and adjust the stacksize:
+
+export CC=gcc-9
+export FC=gfortran-9
+export CXX=g++-9
+ulimit -S -s unlimited
+. /usr/local/ufs-release-v1/bin/setenv_nceplibs.sh
+export CMAKE_Platform=macosx.gnu
+./build.sh 2>&1 | tee build.log
+
+

--- a/doc/README_macos_gccgfortran.txt
+++ b/doc/README_macos_gccgfortran.txt
@@ -4,6 +4,8 @@ The following instructions were tested on a clean macOS systems (Mojave 1.14.6 a
 Homebrew is used to install the GNU (gcc+gfortran) compilers. Note that the export statements are
 required for the subsequent steps, as well as for building NCEPLIBS-external, NCEPLIBS and UFS applications.
 
+Note that 16GB of memory are required for running the UFS weather model at C96 resolution.
+
 1. Install homebrew, the GNU compilers and other utilities:
 
 (1) Install homebrew

--- a/doc/README_redhat_gnu.txt
+++ b/doc/README_redhat_gnu.txt
@@ -1,0 +1,90 @@
+### Red Hat Enterprise Linux 8.1 using gcc-8.3.1 and gfortran-8.3.1
+
+The following instructions were tested on a Red Hat 8 Amazon EC2 compute node, which comes with
+essentially no packages installed. Many of the packages that are installed with yum in the
+following may already be installed on your system. Note that the yum Open MPI library did not
+work correctly in our tests, instead the NCEPLIBS-external MPICH version is used.
+
+A t3a.2xlarge instance with 16 cores and 32GB of memory was used, although a smaller instance
+with 16GB of memory and fewer cores should suffice (need to adjust the number of parallel threads
+for the make calls).
+
+1. Install the GNU compilers and other utilities
+
+sudo su
+# Optional: this is usually a good idea, but should be used with care (it may destroy your existing setup)
+yum update
+# Install gcc-8.3.1, g++-8.3.1 and gfortran-8.3.1
+yum install -y gcc-gfortran gcc-c++
+# Install wget-1.19.5
+yum install -y wget
+# Install git-2.18.2
+yum install -y git
+# Install make-4.2.1
+yum install -y make
+# Install openssl-devel-1.1.1
+yum install -y openssl-devel
+# Install patch-2.7.6
+yum install -y patch
+# Install Python-2.7.16
+yum install -y python2
+alternatives --config python
+# choose /usr/bin/python2
+mkdir /usr/local/ufs-release-v1
+chown -R ec2-user:ec2-user /usr/local/ufs-release-v1
+exit
+
+export CC=gcc
+export CXX=g++
+export FC=gfortran
+
+cd /usr/local/ufs-release-v1
+mkdir src
+
+2.Install missing external libraries from NCEPLIBS-external
+
+The user is referred to the top-level README.md for more detailed instructions on how to build
+NCEPLIBS-external and configure it (e.g., how to turn off building certain packages such as MPI etc).
+The default configuration assumes that all dependencies are built and installed: MPI, netCDF, ...
+
+cd /usr/local/ufs-release-v1/src
+git clone -b ufs-v1.0.0.beta01 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+cd NCEPLIBS-external
+# Install cmake 3.16.3 (default OS version is too old)
+cd cmake-src
+./bootstrap --prefix=/usr/local/ufs-release-v1
+make
+make install
+cd ..
+mkdir build && cd build
+/usr/local/ufs-release-v1/bin/cmake -DCMAKE_INSTALL_PREFIX=/usr/local/ufs-release-v1 .. 2>&1 | tee log.cmake
+make -j8 2>&1 | tee log.make
+
+
+3. Install NCEPLIBS
+
+The user is referred to the top-level README.md of the NCEPLIBS GitHub repository
+(https://github.com/NOAA-EMC/NCEPLIBS/) for more detailed instructions on how to configure
+and build NCEPLIBS. The default configuration assumes that all dependencies were built
+by NCEPLIBS-external as described above.
+
+cd /usr/local/ufs-release-v1/src
+git clone -b ufs-v1.0.0.beta01 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+cd NCEPLIBS
+mkdir build
+cd build
+/usr/local/ufs-release-v1/bin/cmake -DCMAKE_INSTALL_PREFIX=/usr/local/ufs-release-v1 -DEXTERNAL_LIBS_DIR=/usr/local/ufs-release-v1 .. 2>&1 | tee log.cmake
+make -j8 2>&1 | tee log.make
+make install 2>&1 | tee log.install
+```
+
+4. To build the UFS models, source the shell script created by the NCEPLIBS installation and adjust the stacksize:
+
+export CC=gcc
+export CXX=g++
+export FC=gfortran
+ulimit -s unlimited
+. /usr/local/ufs-release-v1/bin/setenv_nceplibs.sh
+export CMAKE_Platform=linux.gnu
+./build.sh 2>&1 | tee build.log
+


### PR DESCRIPTION
This PR moves version-specific documentation from the Wiki into the top-level `README.md` and `doc/README_*.txt for` (system-specific installation notes). To see how the new `README.md` looks like, navigate to https://github.com/climbfuji/NCEPLIBS-external-1/tree/move_documentation_from_wiki.

When this PR gets merged, @ceceliadid will update the wiki.