### PR TITLE
Update tag from ufs-v1.0.0.beta01 to ufs-v1.0.0.beta02 in setup instructions

### DIFF
--- a/doc/README_cheyenne_gnu.txt
+++ b/doc/README_cheyenne_gnu.txt
@@ -16,20 +16,20 @@ export CC=mpicc
 export FC=mpif90
 export CXX=mpicxx
 
-mkdir -p /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta01/gnu-8.3.0/mpt-2.19/src
-cd /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta01/gnu-8.3.0/mpt-2.19/src
+mkdir -p /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta02/gnu-8.3.0/mpt-2.19/src
+cd /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta02/gnu-8.3.0/mpt-2.19/src
 
-git clone -b ufs-v1.0.0.beta01 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+git clone -b ufs-v1.0.0.beta02 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
-cmake -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta01/gnu-8.3.0/mpt-2.19 .. 2>&1 | tee log.cmake
+cmake -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta02/gnu-8.3.0/mpt-2.19 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j2 2>&1 | tee log.make
 
-cd /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta01/gnu-8.3.0/mpt-2.19/src
-git clone -b ufs-v1.0.0.beta01 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+cd /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta02/gnu-8.3.0/mpt-2.19/src
+git clone -b ufs-v1.0.0.beta02 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build && cd build
-cmake -DEXTERNAL_LIBS_DIR=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta01/gnu-8.3.0/mpt-2.19 -DCMAKE_INSTALL_PREFIX=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta01/gnu-8.3.0/mpt-2.19 .. 2>&1 | tee log.cmake
+cmake -DEXTERNAL_LIBS_DIR=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta02/gnu-8.3.0/mpt-2.19 -DCMAKE_INSTALL_PREFIX=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta02/gnu-8.3.0/mpt-2.19 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j2 2>&1 | tee log.make
 make install
 

--- a/doc/README_cheyenne_intel.txt
+++ b/doc/README_cheyenne_intel.txt
@@ -16,20 +16,20 @@ export CC=mpicc
 export FC=mpif90
 export CXX=mpicxx
 
-mkdir -p /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta01/intel-19.0.5/mpt-2.19/src
-cd /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta01/intel-19.0.5/mpt-2.19/src
+mkdir -p /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta02/intel-19.0.5/mpt-2.19/src
+cd /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta02/intel-19.0.5/mpt-2.19/src
 
-git clone -b ufs-v1.0.0.beta01 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+git clone -b ufs-v1.0.0.beta02 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
-cmake -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta01/intel-19.0.5/mpt-2.19 .. 2>&1 | tee log.cmake
+cmake -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta02/intel-19.0.5/mpt-2.19 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j2 2>&1 | tee log.make
 
-cd /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta01/intel-19.0.5/mpt-2.19/src/
-git clone -b ufs-v1.0.0.beta01 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+cd /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta02/intel-19.0.5/mpt-2.19/src/
+git clone -b ufs-v1.0.0.beta02 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build && cd build
-cmake -DEXTERNAL_LIBS_DIR=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta01/intel-19.0.5/mpt-2.19 -DCMAKE_INSTALL_PREFIX=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta01/intel-19.0.5/mpt-2.19 .. 2>&1 | tee log.cmake
+cmake -DEXTERNAL_LIBS_DIR=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta02/intel-19.0.5/mpt-2.19 -DCMAKE_INSTALL_PREFIX=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta02/intel-19.0.5/mpt-2.19 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j2 2>&1 | tee log.make
 make install
 

--- a/doc/README_gaea_intel.txt
+++ b/doc/README_gaea_intel.txt
@@ -21,23 +21,23 @@ export HDF5_ROOT=/opt/cray/pe/hdf5/1.8.16/INTEL/15.0
 export MPI_ROOT=/opt/cray/pe/mpt/7.4.0/gni/mpich-intel/15.0
 export NETCDF=$NETCDF_DIR
 
-mkdir -p /lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0.beta01/intel-18.0.3.222/cray-mpich-7.4.0/src
+mkdir -p /lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0.beta02/intel-18.0.3.222/cray-mpich-7.4.0/src
 
-cd /lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0.beta01/intel-18.0.3.222/cray-mpich-7.4.0/src
+cd /lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0.beta02/intel-18.0.3.222/cray-mpich-7.4.0/src
 # Note: remote access severely limited on gaea; need to do the git clone on a remote system and rsync to gaea
-git clone -b ufs-v1.0.0.beta01 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+git clone -b ufs-v1.0.0.beta02 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
-cmake -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DBUILD_JASPER=OFF -DCMAKE_INSTALL_PREFIX=/lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0.beta01/intel-18.0.3.222/cray-mpich-7.4.0 .. 2>&1 | tee log.cmake
+cmake -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DBUILD_JASPER=OFF -DCMAKE_INSTALL_PREFIX=/lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0.beta02/intel-18.0.3.222/cray-mpich-7.4.0 .. 2>&1 | tee log.cmake
 make VERBOSE=1 2>&1 | tee log.make
 # no make install necessary
 
-cd /lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0.beta01/intel-18.0.3.222/cray-mpich-7.4.0/src
+cd /lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0.beta02/intel-18.0.3.222/cray-mpich-7.4.0/src
 # Note: remote access severely limited on gaea; need to do the git clone on a remote system and rsync to gaea
-git clone -b ufs-v1.0.0.beta01 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+git clone -b ufs-v1.0.0.beta02 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build && cd build
-cmake -DEXTERNAL_LIBS_DIR=/lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0.beta01/intel-18.0.3.222/cray-mpich-7.4.0 -DCMAKE_INSTALL_PREFIX=/lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0.beta01/intel-18.0.3.222/cray-mpich-7.4.0 -DSTATIC_IS_DEFAULT=ON .. 2>&1 | tee log.cmake
+cmake -DEXTERNAL_LIBS_DIR=/lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0.beta02/intel-18.0.3.222/cray-mpich-7.4.0 -DCMAKE_INSTALL_PREFIX=/lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0.beta02/intel-18.0.3.222/cray-mpich-7.4.0 -DSTATIC_IS_DEFAULT=ON .. 2>&1 | tee log.cmake
 make VERBOSE=1 2>&1 | tee log.make
 make install VERBOSE=1 2>&1 | tee log.install
 

--- a/doc/README_hera_intel.txt
+++ b/doc/README_hera_intel.txt
@@ -21,22 +21,22 @@ export FC=ifort
 export HDF5_ROOT=/apps/hdf5/1.10.5/intel/18.0.5.274
 export PNG_ROOT=/usr
 
-mkdir -p /scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0.beta01/intel-18.0.5.274/impi-2018.0.4/src
-cd /scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0.beta01/intel-18.0.5.274/impi-2018.0.4/src
+mkdir -p /scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0.beta02/intel-18.0.5.274/impi-2018.0.4/src
+cd /scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0.beta02/intel-18.0.5.274/impi-2018.0.4/src
 
-git clone -b ufs-v1.0.0.beta01 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+git clone -b ufs-v1.0.0.beta02 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
 
 # If netCDF is not built, also don't build PNG, because netCDF uses the default (OS) zlib in the search path
-cmake -DBUILD_PNG=OFF -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=/scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0.beta01/intel-18.0.5.274/impi-2018.0.4 .. 2>&1 | tee log.cmake
+cmake -DBUILD_PNG=OFF -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=/scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0.beta02/intel-18.0.5.274/impi-2018.0.4 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
 
-cd /scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0.beta01/intel-18.0.5.274/impi-2018.0.4/src
-git clone -b ufs-v1.0.0.beta01 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+cd /scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0.beta02/intel-18.0.5.274/impi-2018.0.4/src
+git clone -b ufs-v1.0.0.beta02 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build && cd build
-cmake -DEXTERNAL_LIBS_DIR=/scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0.beta01/intel-18.0.5.274/impi-2018.0.4 -DCMAKE_INSTALL_PREFIX=/scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0.beta01/intel-18.0.5.274/impi-2018.0.4 .. 2>&1 | tee log.cmake
+cmake -DEXTERNAL_LIBS_DIR=/scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0.beta02/intel-18.0.5.274/impi-2018.0.4 -DCMAKE_INSTALL_PREFIX=/scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0.beta02/intel-18.0.5.274/impi-2018.0.4 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
 make install
 

--- a/doc/README_jet_intel.txt
+++ b/doc/README_jet_intel.txt
@@ -21,22 +21,22 @@ export CXX=icpc
 export HDF5_ROOT=/apps/hdf5/1.10.5/intel/18.0.5.274
 export PNG_ROOT=/usr
 
-mkdir -p /lfs3/projects/hfv3gfs/GMTB/NCEPlibs-ufs-v1.0.0.beta01/intel-18.0.5.274/impi-2018.4.274/src
-cd /lfs3/projects/hfv3gfs/GMTB/NCEPlibs-ufs-v1.0.0.beta01/intel-18.0.5.274/impi-2018.4.274/src
+mkdir -p /lfs3/projects/hfv3gfs/GMTB/NCEPlibs-ufs-v1.0.0.beta02/intel-18.0.5.274/impi-2018.4.274/src
+cd /lfs3/projects/hfv3gfs/GMTB/NCEPlibs-ufs-v1.0.0.beta02/intel-18.0.5.274/impi-2018.4.274/src
 
-git clone -b ufs-v1.0.0.beta01 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+git clone -b ufs-v1.0.0.beta02 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
 
 # If netCDF is not built, also don't build PNG, because netCDF uses the default (OS) zlib in the search path
-cmake -DBUILD_PNG=OFF -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=/lfs3/projects/hfv3gfs/GMTB/NCEPlibs-ufs-v1.0.0.beta01/intel-18.0.5.274/impi-2018.4.274 .. 2>&1 | tee log.cmake
+cmake -DBUILD_PNG=OFF -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=/lfs3/projects/hfv3gfs/GMTB/NCEPlibs-ufs-v1.0.0.beta02/intel-18.0.5.274/impi-2018.4.274 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
 
-cd /lfs3/projects/hfv3gfs/GMTB/NCEPlibs-ufs-v1.0.0.beta01/intel-18.0.5.274/impi-2018.4.274/src
-git clone -b ufs-v1.0.0.beta01 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+cd /lfs3/projects/hfv3gfs/GMTB/NCEPlibs-ufs-v1.0.0.beta02/intel-18.0.5.274/impi-2018.4.274/src
+git clone -b ufs-v1.0.0.beta02 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build && cd build
-cmake -DEXTERNAL_LIBS_DIR=/lfs3/projects/hfv3gfs/GMTB/NCEPlibs-ufs-v1.0.0.beta01/intel-18.0.5.274/impi-2018.4.274 -DCMAKE_INSTALL_PREFIX=/lfs3/projects/hfv3gfs/GMTB/NCEPlibs-ufs-v1.0.0.beta01/intel-18.0.5.274/impi-2018.4.274 .. 2>&1 | tee log.cmake
+cmake -DEXTERNAL_LIBS_DIR=/lfs3/projects/hfv3gfs/GMTB/NCEPlibs-ufs-v1.0.0.beta02/intel-18.0.5.274/impi-2018.4.274 -DCMAKE_INSTALL_PREFIX=/lfs3/projects/hfv3gfs/GMTB/NCEPlibs-ufs-v1.0.0.beta02/intel-18.0.5.274/impi-2018.4.274 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
 make install
 

--- a/doc/README_macos_clanggfortran.txt
+++ b/doc/README_macos_clanggfortran.txt
@@ -52,7 +52,7 @@ NCEPLIBS-external and configure it (e.g., how to turn off building certain packa
 The default configuration assumes that all dependencies are built and installed: MPI, netCDF, ...
 
 cd /usr/local/ufs-release-v1/src
-git clone -b ufs-v1.0.0.beta01 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+git clone -b ufs-v1.0.0.beta02 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=/usr/local/ufs-release-v1 .. 2>&1 | tee log.cmake
@@ -67,7 +67,7 @@ and build NCEPLIBS. The default configuration assumes that all dependencies were
 by NCEPLIBS-external as described above.
 
 cd /usr/local/ufs-release-v1/src
-git clone -b ufs-v1.0.0.beta01 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+git clone -b ufs-v1.0.0.beta02 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build
 cd build

--- a/doc/README_macos_gccgfortran.txt
+++ b/doc/README_macos_gccgfortran.txt
@@ -48,7 +48,7 @@ NCEPLIBS-external and configure it (e.g., how to turn off building certain packa
 The default configuration assumes that all dependencies are built and installed: MPI, netCDF, ...
 
 cd /usr/local/ufs-release-v1/src
-git clone -b ufs-v1.0.0.beta01 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+git clone -b ufs-v1.0.0.beta02 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=/usr/local/ufs-release-v1 .. 2>&1 | tee log.cmake
@@ -63,7 +63,7 @@ and build NCEPLIBS. The default configuration assumes that all dependencies were
 by NCEPLIBS-external as described above.
 
 cd /usr/local/ufs-release-v1/src
-git clone -b ufs-v1.0.0.beta01 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+git clone -b ufs-v1.0.0.beta02 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build
 cd build

--- a/doc/README_redhat_gnu.txt
+++ b/doc/README_redhat_gnu.txt
@@ -48,7 +48,7 @@ NCEPLIBS-external and configure it (e.g., how to turn off building certain packa
 The default configuration assumes that all dependencies are built and installed: MPI, netCDF, ...
 
 cd /usr/local/ufs-release-v1/src
-git clone -b ufs-v1.0.0.beta01 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+git clone -b ufs-v1.0.0.beta02 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 # Install cmake 3.16.3 (default OS version is too old)
 cd cmake-src
@@ -69,7 +69,7 @@ and build NCEPLIBS. The default configuration assumes that all dependencies were
 by NCEPLIBS-external as described above.
 
 cd /usr/local/ufs-release-v1/src
-git clone -b ufs-v1.0.0.beta01 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+git clone -b ufs-v1.0.0.beta02 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build
 cd build


### PR DESCRIPTION
Update tag from `ufs-v1.0.0.beta01` to `ufs-v1.0.0.beta02` in setup instructions. Will recreate the tag after the merge. No code changes.