### PR TITLE
Update documentation for final release tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ For building NCEPLIBS-external, use `/full_path_to_where_you_installed_cmake/bin
 
 | Compiler vendor | Supported (tested) versions                                |
 |-----------------|------------------------------------------------------------|
-| Intel           | 18.0.3.222, 18.0.5.274, 19.0.2.187, 19.0.5.281             |
+| Intel           | 18.0.3.222, 18.0.5.274, 19.0.2.187, 19.0.5.281, 19.1.0.166 |
 | GNU             | 8.3.0, 9.1.0, 9.2.0                                        |
 
 3. A supported MPI library unless installed as part of NCEPLIBS-external, see table below. Other versions may work, in particular if close to the versions listed below. It is recommended to compile the MPI library with the same compilers used to compile NCEPLIBS-external.
@@ -52,7 +52,7 @@ For building NCEPLIBS-external, use `/full_path_to_where_you_installed_cmake/bin
 | MPICH           | 3.3.1, 3.3.2                                               |
 | MVAPICH2        | 2.3.3                                                      |
 | Open MPI        | 4.0.2                                                      |
-| Intel MPI       | 2018.0.4, 2019.6.154                                       |
+| Intel MPI       | 2018.0.4, 2019.6.154, 2020.0.166                           |
 | SGI MPT         | 2.19                                                       |
 
 ### Prepare to Build 

--- a/doc/README_cheyenne_gnu.txt
+++ b/doc/README_cheyenne_gnu.txt
@@ -16,20 +16,20 @@ export CC=mpicc
 export FC=mpif90
 export CXX=mpicxx
 
-mkdir -p /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta04/gnu-8.3.0/mpt-2.19/src
-cd /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta04/gnu-8.3.0/mpt-2.19/src
+mkdir -p /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0/gnu-8.3.0/mpt-2.19/src
+cd /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0/gnu-8.3.0/mpt-2.19/src
 
-git clone -b ufs-v1.0.0.beta04 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
-cmake -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DBUILD_PNG=OFF -DCMAKE_INSTALL_PREFIX=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta04/gnu-8.3.0/mpt-2.19 .. 2>&1 | tee log.cmake
+cmake -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DBUILD_PNG=OFF -DCMAKE_INSTALL_PREFIX=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0/gnu-8.3.0/mpt-2.19 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j2 2>&1 | tee log.make
 
-cd /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta04/gnu-8.3.0/mpt-2.19/src
-git clone -b ufs-v1.0.0.beta04 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+cd /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0/gnu-8.3.0/mpt-2.19/src
+git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build && cd build
-cmake -DEXTERNAL_LIBS_DIR=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta04/gnu-8.3.0/mpt-2.19 -DCMAKE_INSTALL_PREFIX=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta04/gnu-8.3.0/mpt-2.19 .. 2>&1 | tee log.cmake
+cmake -DEXTERNAL_LIBS_DIR=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0/gnu-8.3.0/mpt-2.19 -DCMAKE_INSTALL_PREFIX=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0/gnu-8.3.0/mpt-2.19 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j2 2>&1 | tee log.make
 make install
 
@@ -49,7 +49,7 @@ export FC=mpif90
 export CXX=mpicxx
 
 module use -a /glade/p/ral/jntp/GMTB/tools/modulefiles/gnu-8.3.0/mpt-2.19
-module load  NCEPlibs/1.0.0beta04
+module load  NCEPlibs/1.0.0
 
 export CMAKE_Platform=cheyenne.gnu
 ./build.sh 2>&1 | tee build.log

--- a/doc/README_cheyenne_intel.txt
+++ b/doc/README_cheyenne_intel.txt
@@ -16,20 +16,20 @@ export CC=mpicc
 export FC=mpif90
 export CXX=mpicxx
 
-mkdir -p /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta04/intel-19.0.5/mpt-2.19/src
-cd /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta04/intel-19.0.5/mpt-2.19/src
+mkdir -p /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0/intel-19.0.5/mpt-2.19/src
+cd /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0/intel-19.0.5/mpt-2.19/src
 
-git clone -b ufs-v1.0.0.beta04 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
-cmake -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DBUILD_PNG=OFF -DCMAKE_INSTALL_PREFIX=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta04/intel-19.0.5/mpt-2.19 .. 2>&1 | tee log.cmake
+cmake -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DBUILD_PNG=OFF -DCMAKE_INSTALL_PREFIX=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0/intel-19.0.5/mpt-2.19 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j2 2>&1 | tee log.make
 
-cd /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta04/intel-19.0.5/mpt-2.19/src/
-git clone -b ufs-v1.0.0.beta04 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+cd /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0/intel-19.0.5/mpt-2.19/src/
+git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build && cd build
-cmake -DEXTERNAL_LIBS_DIR=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta04/intel-19.0.5/mpt-2.19 -DCMAKE_INSTALL_PREFIX=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0.beta04/intel-19.0.5/mpt-2.19 .. 2>&1 | tee log.cmake
+cmake -DEXTERNAL_LIBS_DIR=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0/intel-19.0.5/mpt-2.19 -DCMAKE_INSTALL_PREFIX=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0/intel-19.0.5/mpt-2.19 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j2 2>&1 | tee log.make
 make install
 
@@ -49,7 +49,7 @@ export FC=mpif90
 export CXX=mpicxx
 
 module use -a /glade/p/ral/jntp/GMTB/tools/modulefiles/intel-19.0.5/mpt-2.19
-module load  NCEPlibs/1.0.0beta04
+module load  NCEPlibs/1.0.0
 
 export CMAKE_Platform=cheyenne.intel
 ./build.sh 2>&1 | tee build.log

--- a/doc/README_gaea_intel.txt
+++ b/doc/README_gaea_intel.txt
@@ -22,22 +22,22 @@ export FC=ftn
 export CXX=CC
 export MPI_ROOT=/opt/cray/pe/mpt/7.7.3/gni/mpich-intel/16.0
 
-mkdir -p /lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0.beta04/intel-18.0.3.222/cray-mpich-7.7.3/src
+mkdir -p /lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0/intel-18.0.3.222/cray-mpich-7.7.3/src
 
-cd /lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0.beta04/intel-18.0.3.222/cray-mpich-7.7.3/src
+cd /lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0/intel-18.0.3.222/cray-mpich-7.7.3/src
 # Note: remote access severely limited on gaea; need to do the git clone on a remote system and rsync to gaea
-git clone -b ufs-v1.0.0.beta04 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 mkdir build && cd build
-cmake -DBUILD_MPI=OFF -DSTATIC_IS_DEFAULT=ON -DCMAKE_INSTALL_PREFIX=/lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0.beta04/intel-18.0.3.222/cray-mpich-7.7.3 .. 2>&1 | tee log.cmake
+cmake -DBUILD_MPI=OFF -DSTATIC_IS_DEFAULT=ON -DCMAKE_INSTALL_PREFIX=/lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0/intel-18.0.3.222/cray-mpich-7.7.3 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
 # no make install necessary
 
-cd /lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0.beta04/intel-18.0.3.222/cray-mpich-7.7.3/src
+cd /lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0/intel-18.0.3.222/cray-mpich-7.7.3/src
 # Note: remote access severely limited on gaea; need to do the git clone on a remote system and rsync to gaea
-git clone -b ufs-v1.0.0.beta04 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build && cd build
-cmake -DEXTERNAL_LIBS_DIR=/lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0.beta04/intel-18.0.3.222/cray-mpich-7.7.3 -DCMAKE_INSTALL_PREFIX=/lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0.beta04/intel-18.0.3.222/cray-mpich-7.7.3 -DSTATIC_IS_DEFAULT=ON .. 2>&1 | tee log.cmake
+cmake -DEXTERNAL_LIBS_DIR=/lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0/intel-18.0.3.222/cray-mpich-7.7.3 -DCMAKE_INSTALL_PREFIX=/lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0/intel-18.0.3.222/cray-mpich-7.7.3 -DSTATIC_IS_DEFAULT=ON .. 2>&1 | tee log.cmake
 make VERBOSE=1 2>&1 | tee log.make
 make install VERBOSE=1 2>&1 | tee log.install
 
@@ -53,7 +53,7 @@ module use -a /lustre/f2/pdata/esrl/gsd/ufs/modules/modulefiles/generic
 module load cmake/3.16.4
 
 module use -a /lustre/f2/pdata/esrl/gsd/ufs/modules/modulefiles/intel-18.0.3.222
-module load NCEPlibs/1.0.0.beta04
+module load NCEPlibs/1.0.0
 
 export CMAKE_Platform=gaea.intel
 export CMAKE_C_COMPILER=cc

--- a/doc/README_hera_intel.txt
+++ b/doc/README_hera_intel.txt
@@ -21,21 +21,21 @@ export FC=ifort
 export HDF5_ROOT=/apps/hdf5/1.10.5/intel/18.0.5.274
 export PNG_ROOT=/usr
 
-mkdir -p /scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0.beta04/intel-18.0.5.274/impi-2018.0.4/src
-cd /scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0.beta04/intel-18.0.5.274/impi-2018.0.4/src
+mkdir -p /scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0/intel-18.0.5.274/impi-2018.0.4/src
+cd /scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0/intel-18.0.5.274/impi-2018.0.4/src
 
-git clone -b ufs-v1.0.0.beta04 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
 # If netCDF is not built, also don't build PNG, because netCDF uses the default (OS) zlib in the search path
-cmake -DBUILD_PNG=OFF -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=/scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0.beta04/intel-18.0.5.274/impi-2018.0.4 .. 2>&1 | tee log.cmake
+cmake -DBUILD_PNG=OFF -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=/scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0/intel-18.0.5.274/impi-2018.0.4 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
 
-cd /scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0.beta04/intel-18.0.5.274/impi-2018.0.4/src
-git clone -b ufs-v1.0.0.beta04 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+cd /scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0/intel-18.0.5.274/impi-2018.0.4/src
+git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build && cd build
-cmake -DEXTERNAL_LIBS_DIR=/scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0.beta04/intel-18.0.5.274/impi-2018.0.4 -DCMAKE_INSTALL_PREFIX=/scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0.beta04/intel-18.0.5.274/impi-2018.0.4 .. 2>&1 | tee log.cmake
+cmake -DEXTERNAL_LIBS_DIR=/scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0/intel-18.0.5.274/impi-2018.0.4 -DCMAKE_INSTALL_PREFIX=/scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0/intel-18.0.5.274/impi-2018.0.4 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
 make install
 
@@ -53,7 +53,7 @@ export CXX=icpc
 export FC=ifort
 
 module use -a /scratch1/BMC/gmtb/software/modulefiles/intel-18.0.5.274/impi-2018.0.4
-module load NCEPlibs/1.0.0beta04
+module load  NCEPlibs/1.0.0
 
 export CMAKE_Platform=hera.intel
 ./build.sh 2>&1 | tee build.log

--- a/doc/README_jet_intel.txt
+++ b/doc/README_jet_intel.txt
@@ -21,21 +21,21 @@ export CXX=icpc
 export HDF5_ROOT=/apps/hdf5/1.10.5/intel/18.0.5.274
 export PNG_ROOT=/usr
 
-mkdir -p /lfs3/projects/hfv3gfs/GMTB/NCEPlibs-ufs-v1.0.0.beta04/intel-18.0.5.274/impi-2018.4.274/src
-cd /lfs3/projects/hfv3gfs/GMTB/NCEPlibs-ufs-v1.0.0.beta04/intel-18.0.5.274/impi-2018.4.274/src
+mkdir -p /lfs3/projects/hfv3gfs/GMTB/NCEPlibs-ufs-v1.0.0/intel-18.0.5.274/impi-2018.4.274/src
+cd /lfs3/projects/hfv3gfs/GMTB/NCEPlibs-ufs-v1.0.0/intel-18.0.5.274/impi-2018.4.274/src
 
-git clone -b ufs-v1.0.0.beta04 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
 # If netCDF is not built, also don't build PNG, because netCDF uses the default (OS) zlib in the search path
-cmake -DBUILD_PNG=OFF -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=/lfs3/projects/hfv3gfs/GMTB/NCEPlibs-ufs-v1.0.0.beta04/intel-18.0.5.274/impi-2018.4.274 .. 2>&1 | tee log.cmake
+cmake -DBUILD_PNG=OFF -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=/lfs3/projects/hfv3gfs/GMTB/NCEPlibs-ufs-v1.0.0/intel-18.0.5.274/impi-2018.4.274 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
 
-cd /lfs3/projects/hfv3gfs/GMTB/NCEPlibs-ufs-v1.0.0.beta04/intel-18.0.5.274/impi-2018.4.274/src
-git clone -b ufs-v1.0.0.beta04 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+cd /lfs3/projects/hfv3gfs/GMTB/NCEPlibs-ufs-v1.0.0/intel-18.0.5.274/impi-2018.4.274/src
+git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build && cd build
-cmake -DEXTERNAL_LIBS_DIR=/lfs3/projects/hfv3gfs/GMTB/NCEPlibs-ufs-v1.0.0.beta04/intel-18.0.5.274/impi-2018.4.274 -DCMAKE_INSTALL_PREFIX=/lfs3/projects/hfv3gfs/GMTB/NCEPlibs-ufs-v1.0.0.beta04/intel-18.0.5.274/impi-2018.4.274 .. 2>&1 | tee log.cmake
+cmake -DEXTERNAL_LIBS_DIR=/lfs3/projects/hfv3gfs/GMTB/NCEPlibs-ufs-v1.0.0/intel-18.0.5.274/impi-2018.4.274 -DCMAKE_INSTALL_PREFIX=/lfs3/projects/hfv3gfs/GMTB/NCEPlibs-ufs-v1.0.0/intel-18.0.5.274/impi-2018.4.274 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
 make install
 
@@ -54,7 +54,7 @@ export FC=ifort
 export CXX=icpc
 
 module use -a /lfs3/projects/hfv3gfs/GMTB/modulefiles/intel-18.0.5.274/impi-2018.4.274
-module load NCEPlibs/1.0.0beta04
+module load  NCEPlibs/1.0.0
 
 export CMAKE_Platform=jet.intel
 ./build.sh 2>&1 | tee build.log

--- a/doc/README_macos_clanggfortran.txt
+++ b/doc/README_macos_clanggfortran.txt
@@ -30,6 +30,11 @@ brew install gcc@9
 
 brew install llvm@9
 
+export PATH="/usr/local/opt/llvm/bin:$PATH"
+export LD_LIBRARY_PATH="/usr/local/opt/llvm/lib:$LD_LIBRARY_PATH"
+export CPPFLAGS="-I/usr/local/opt/llvm/include"
+export LDFLAGS="-L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib"
+
 export CC=clang-9
 export FC=gfortran-9
 export CXX=clang++-9
@@ -52,7 +57,7 @@ NCEPLIBS-external and configure it (e.g., how to turn off building certain packa
 The default configuration assumes that all dependencies are built and installed: MPI, netCDF, ...
 
 cd /usr/local/ufs-release-v1/src
-git clone -b ufs-v1.0.0.beta04 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=/usr/local/ufs-release-v1 .. 2>&1 | tee log.cmake
@@ -67,7 +72,7 @@ and build NCEPLIBS. The default configuration assumes that all dependencies were
 by NCEPLIBS-external as described above.
 
 cd /usr/local/ufs-release-v1/src
-git clone -b ufs-v1.0.0.beta04 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build
 cd build
@@ -80,6 +85,10 @@ make install 2>&1 | tee log.install
 export CC=clang-9
 export FC=gfortran-9
 export CXX=clang++-9
+export PATH="/usr/local/opt/llvm/bin:$PATH"
+export LD_LIBRARY_PATH="/usr/local/opt/llvm/lib:$LD_LIBRARY_PATH"
+export CPPFLAGS="-I/usr/local/opt/llvm/include"
+export LDFLAGS="-L/usr/local/opt/llvm/lib -Wl,-rpath,/usr/local/opt/llvm/lib"
 ulimit -S -s unlimited
 . /usr/local/ufs-release-v1/bin/setenv_nceplibs.sh
 export CMAKE_Platform=macosx.gnu

--- a/doc/README_macos_gccgfortran.txt
+++ b/doc/README_macos_gccgfortran.txt
@@ -48,7 +48,7 @@ NCEPLIBS-external and configure it (e.g., how to turn off building certain packa
 The default configuration assumes that all dependencies are built and installed: MPI, netCDF, ...
 
 cd /usr/local/ufs-release-v1/src
-git clone -b ufs-v1.0.0.beta04 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=/usr/local/ufs-release-v1 .. 2>&1 | tee log.cmake
@@ -63,7 +63,7 @@ and build NCEPLIBS. The default configuration assumes that all dependencies were
 by NCEPLIBS-external as described above.
 
 cd /usr/local/ufs-release-v1/src
-git clone -b ufs-v1.0.0.beta04 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build
 cd build

--- a/doc/README_orion_intel.txt
+++ b/doc/README_orion_intel.txt
@@ -20,21 +20,21 @@ export FC=ifort
 export HDF5_ROOT=/apps/intel-2020/hdf5-1.10.5
 export PNG_ROOT=/usr
 
-mkdir -p /work/noaa/gmtb/dheinzel/NCEPLIBS-ufs-v1.0.0.beta04/intel-19.1.0.166/impi-2020.0.166/src
-cd /work/noaa/gmtb/dheinzel/NCEPLIBS-ufs-v1.0.0.beta04/intel-19.1.0.166/impi-2020.0.166/src
+mkdir -p /work/noaa/gmtb/dheinzel/NCEPLIBS-ufs-v1.0.0/intel-19.1.0.166/impi-2020.0.166/src
+cd /work/noaa/gmtb/dheinzel/NCEPLIBS-ufs-v1.0.0/intel-19.1.0.166/impi-2020.0.166/src
 
-git clone -b ufs-v1.0.0.beta04 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
 # If netCDF is not built, also don't build PNG, because netCDF uses the default (OS) zlib in the search path
-cmake -DBUILD_PNG=OFF -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=/work/noaa/gmtb/dheinzel/NCEPLIBS-ufs-v1.0.0.beta04/intel-19.1.0.166/impi-2020.0.166 .. 2>&1 | tee log.cmake
+cmake -DBUILD_PNG=OFF -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=/work/noaa/gmtb/dheinzel/NCEPLIBS-ufs-v1.0.0/intel-19.1.0.166/impi-2020.0.166 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
 
-cd /work/noaa/gmtb/dheinzel/NCEPLIBS-ufs-v1.0.0.beta04/intel-19.1.0.166/impi-2020.0.166/src
-git clone -b ufs-v1.0.0.beta04 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+cd /work/noaa/gmtb/dheinzel/NCEPLIBS-ufs-v1.0.0/intel-19.1.0.166/impi-2020.0.166/src
+git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build && cd build
-cmake -DEXTERNAL_LIBS_DIR=/work/noaa/gmtb/dheinzel/NCEPLIBS-ufs-v1.0.0.beta04/intel-19.1.0.166/impi-2020.0.166 -DCMAKE_INSTALL_PREFIX=/work/noaa/gmtb/dheinzel/NCEPLIBS-ufs-v1.0.0.beta04/intel-19.1.0.166/impi-2020.0.166 .. 2>&1 | tee log.cmake
+cmake -DEXTERNAL_LIBS_DIR=/work/noaa/gmtb/dheinzel/NCEPLIBS-ufs-v1.0.0/intel-19.1.0.166/impi-2020.0.166 -DCMAKE_INSTALL_PREFIX=/work/noaa/gmtb/dheinzel/NCEPLIBS-ufs-v1.0.0/intel-19.1.0.166/impi-2020.0.166 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
 make install
 
@@ -52,7 +52,7 @@ export CMAKE_C_COMPILER=mpiicc
 export CMAKE_CXX_COMPILER=mpiicpc
 export CMAKE_Fortran_COMPILER=mpiifort
 
-. /work/noaa/gmtb/dheinzel/NCEPLIBS-ufs-v1.0.0.beta04/intel-19.1.0.166/impi-2020.0.166/bin/setenv_nceplibs.sh
+. /work/noaa/gmtb/dheinzel/NCEPLIBS-ufs-v1.0.0/intel-19.1.0.166/impi-2020.0.166/bin/setenv_nceplibs.sh
 export CMAKE_Platform=orion.intel
 cp cmake/configure_hera.intel.cmake cmake/configure_orion.intel.cmake
 ./build.sh 2>&1 | tee build.log

--- a/doc/README_redhat_gnu.txt
+++ b/doc/README_redhat_gnu.txt
@@ -51,7 +51,7 @@ NCEPLIBS-external and configure it (e.g., how to turn off building certain packa
 The default configuration assumes that all dependencies are built and installed: MPI, netCDF, ...
 
 cd /usr/local/ufs-release-v1/src
-git clone -b ufs-v1.0.0.beta04 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 # Install cmake 3.16.3 (default OS version is too old)
 cd cmake-src
@@ -72,7 +72,7 @@ and build NCEPLIBS. The default configuration assumes that all dependencies were
 by NCEPLIBS-external as described above.
 
 cd /usr/local/ufs-release-v1/src
-git clone -b ufs-v1.0.0.beta04 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build
 cd build

--- a/doc/README_stampede_intel.txt
+++ b/doc/README_stampede_intel.txt
@@ -25,22 +25,22 @@ export CXX=icpc
 export NETCDF=${TACC_NETCDF_DIR}
 export HDF5_ROOT=/opt/apps/intel18/hdf5/1.10.4/x86_64
 
-mkdir -p $WORK/NCEPLIBS-ufs-v1.0.0.beta04/src
-# for this particular user, this corresponds to /work/06146/tg854455/stampede2/NCEPLIBS-ufs-v1.0.0.beta04/src
+mkdir -p $WORK/NCEPLIBS-ufs-v1.0.0/src
+# for this particular user, this corresponds to /work/06146/tg854455/stampede2/NCEPLIBS-ufs-v1.0.0/src
 
-cd $WORK/NCEPLIBS-ufs-v1.0.0.beta04/src
-git clone -b ufs-v1.0.0.beta04 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+cd $WORK/NCEPLIBS-ufs-v1.0.0/src
+git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
 # If netCDF is not built, also don't build PNG, because netCDF uses the default (OS) zlib in the search path
-cmake -DBUILD_MPI=OFF -DBUILD_PNG=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=$WORK/NCEPLIBS-ufs-v1.0.0.beta04 .. 2>&1 | tee log.cmake
+cmake -DBUILD_MPI=OFF -DBUILD_PNG=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=$WORK/NCEPLIBS-ufs-v1.0.0 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
 
-cd $WORK/NCEPLIBS-ufs-v1.0.0.beta04/src
-git clone -b ufs-v1.0.0.beta04 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+cd $WORK/NCEPLIBS-ufs-v1.0.0/src
+git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build && cd build
-cmake -DEXTERNAL_LIBS_DIR=$WORK/NCEPLIBS-ufs-v1.0.0.beta04 -DCMAKE_INSTALL_PREFIX=$WORK/NCEPLIBS-ufs-v1.0.0.beta04 .. 2>&1 | tee log.cmake
+cmake -DEXTERNAL_LIBS_DIR=$WORK/NCEPLIBS-ufs-v1.0.0 -DCMAKE_INSTALL_PREFIX=$WORK/NCEPLIBS-ufs-v1.0.0 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
 make install
 
@@ -67,6 +67,6 @@ export FC=ifort
 export CXX=icpc
 export NETCDF=${TACC_NETCDF_DIR}
 
-. $WORK/NCEPLIBS-ufs-v1.0.0.beta04/bin/setenv_nceplibs.sh
+. $WORK/NCEPLIBS-ufs-v1.0.0/bin/setenv_nceplibs.sh
 export CMAKE_Platform=stampede.intel
 ./build.sh 2>&1 | tee build.log

--- a/doc/README_ubuntu_gnu.txt
+++ b/doc/README_ubuntu_gnu.txt
@@ -58,7 +58,7 @@ NCEPLIBS-external and configure it (e.g., how to turn off building certain packa
 The default configuration assumes that all dependencies are built and installed: MPI, netCDF, ...
 
 cd /usr/local/ufs-release-v1/src
-git clone -b ufs-v1.0.0.beta04 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 # Install cmake 3.16.3 (default OS version is too old)
 cd cmake-src
@@ -78,7 +78,7 @@ and build NCEPLIBS. The default configuration assumes that all dependencies were
 by NCEPLIBS-external as described above.
 
 cd /usr/local/ufs-release-v1/src
-git clone -b ufs-v1.0.0.beta04 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build
 cd build


### PR DESCRIPTION
This PR updates the documentation for the final release tag of NCEPLIBS-external and NCEPLIBS. No code changes. This should be merged just before creating and rolling out the final release tags of NCEPLIBS and NCEPLIBS-external.

Associated PR: https://github.com/NOAA-EMC/NCEPLIBS/pull/63