### PR TITLE
Documentation updates for orion and stampede

### DIFF
--- a/doc/README_gaea_intel.txt
+++ b/doc/README_gaea_intel.txt
@@ -27,6 +27,7 @@ mkdir -p /lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0/intel-18.0.3.
 cd /lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0/intel-18.0.3.222/cray-mpich-7.7.3/src
 # Note: remote access severely limited on gaea; need to do the git clone on a remote system and rsync to gaea
 git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+cd NCEPLIBS-external
 mkdir build && cd build
 cmake -DBUILD_MPI=OFF -DSTATIC_IS_DEFAULT=ON -DCMAKE_INSTALL_PREFIX=/lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0/intel-18.0.3.222/cray-mpich-7.7.3 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
@@ -38,7 +39,7 @@ git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build && cd build
 cmake -DEXTERNAL_LIBS_DIR=/lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0/intel-18.0.3.222/cray-mpich-7.7.3 -DCMAKE_INSTALL_PREFIX=/lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0/intel-18.0.3.222/cray-mpich-7.7.3 -DSTATIC_IS_DEFAULT=ON .. 2>&1 | tee log.cmake
-make VERBOSE=1 2>&1 | tee log.make
+make VERBOSE=1 -j8 2>&1 | tee log.make
 make install VERBOSE=1 2>&1 | tee log.install
 
 

--- a/doc/README_orion_intel.txt
+++ b/doc/README_orion_intel.txt
@@ -8,7 +8,7 @@ module load cmake/3.15.4
 module li
 
 > Currently Loaded Modules:
->  1) intel/18.0.5.274   2) impi/2018.0.4   3) netcdf/4.7.0   4) cmake/3.16.3
+  1) intel/2020   2) munge/0.5.13   3) slurm/19.05.3-2   4) impi/2020   5) hdf5/1.10.5   6) netcdf/4.7.2   7) cmake/3.15.4
 
 # Note: HDF5 is in: /apps/hdf5/1.10.5/intel/18.0.5.274
 # Note: ZLIB and PNG are in: /usr/include, /usr/lib64/
@@ -36,7 +36,7 @@ cd NCEPLIBS
 mkdir build && cd build
 cmake -DEXTERNAL_LIBS_DIR=/work/noaa/gmtb/dheinzel/NCEPLIBS-ufs-v1.0.0/intel-19.1.0.166/impi-2020.0.166 -DCMAKE_INSTALL_PREFIX=/work/noaa/gmtb/dheinzel/NCEPLIBS-ufs-v1.0.0/intel-19.1.0.166/impi-2020.0.166 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
-make install
+make install 2>&1 | tee log.install
 
 
 How to build the model with those libraries installed:

--- a/doc/README_stampede_intel.txt
+++ b/doc/README_stampede_intel.txt
@@ -42,7 +42,7 @@ cd NCEPLIBS
 mkdir build && cd build
 cmake -DEXTERNAL_LIBS_DIR=$WORK/NCEPLIBS-ufs-v1.0.0 -DCMAKE_INSTALL_PREFIX=$WORK/NCEPLIBS-ufs-v1.0.0 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
-make install
+make install 2>&1 | tee log.install
 
 
 How to build the model with those libraries installed:


### PR DESCRIPTION
Documentation updates for orion and stampede only - no code changes. Will merge and recreate tag ufs-v1.0.0 for the last time.