### PR TITLE
post-release: automatic testing (continuous integration) of build on macOS with gcc+gfortran

### DIFF
--- a/.github/workflows/macos-gccgfortran.yml
+++ b/.github/workflows/macos-gccgfortran.yml
@@ -1,0 +1,31 @@
+name: Build macOS gccgfortran
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: macos-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Init submodules
+      run: git submodule update --init --recursive
+    - name: Update packages
+      run: |
+        /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+        brew install autoconf automake coreutils gcc@9 libtool mpich gnu-sed wget git
+    - name: Build NCEPLIBS-external
+      run: |
+        export CC=gcc-9
+        export FC=gfortran-9
+        export CXX=g++-9
+        mkdir build
+        cd build
+        cmake -DCMAKE_INSTALL_PREFIX=$PWD/../install .. 2>&1 | tee log.cmake
+        make -j8 2>&1 | tee log.make
+        cd ..
+        ls -l install/bin/ESMF_Info
+        ls -l install/bin/wgrib2
+        cat install/share/nceplibs-external.cmake.config


### PR DESCRIPTION
This PR adds an action script to enable continuous integration (automatic testing) of the NCEPLIBS-external build on macOS with gcc+gfortran.