### PR TITLE
Documentation update for Hera with GNU compilers

### DIFF
--- a/.github/workflows/macos-gccgfortran.yml
+++ b/.github/workflows/macos-gccgfortran.yml
@@ -15,7 +15,8 @@ jobs:
     - name: Update packages
       run: |
         /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-        brew install autoconf automake coreutils gcc@9 libtool mpich gnu-sed wget
+        #brew install autoconf automake coreutils gcc@9 libtool mpich gnu-sed wget
+        brew install automake coreutils mpich gnu-sed
     - name: Build NCEPLIBS-external
       run: |
         export CC=gcc-9

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Note that Windows systems and other compilers (e.g. PGI) are not supported at th
 Pre-configured systems do have existing installations of NCEPLIBS-external and NCEPLIBS. Users should not have to build any of these unless new versions of the external libraries or the NCEPLIBS are to be tested. In this case, the following instructions will be useful to repeat the steps the UFS developers have taken. They can also be useful for users trying to install NCEPLIBS-external and NCEPLIBS on other HPC platforms with preinstalled MPI, netCDF, ...
 
 - Installation notes for NOAA RDHPC Hera using icc and ifort: `doc/README_hera_intel.txt`
+- Installation notes for NOAA RDHPC Hera using gcc and gfortran: `doc/README_hera_gnu.txt`
 - Installation notes for NOAA RDHPC Jet using icc and ifort: `doc/README_jet_intel.txt`
 - Installation notes for NOAA RDHPC Gaea using icc and ifort: `doc/README_gaea_intel.txt`
 - Installation notes for CISL Cheyenne using icc and ifort: `doc/README_cheyenne_intel.txt`

--- a/doc/README_cheyenne_gnu.txt
+++ b/doc/README_cheyenne_gnu.txt
@@ -34,7 +34,19 @@ make VERBOSE=1 -j2 2>&1 | tee log.make
 make install
 
 
-How to build the ufs-weather-model (standalone; not the ufs-mrweather app - for the latter, the model is built by the workflow) with those libraries installed:
+- END OF THE SETUP INSTRUCTIONS -
+
+
+The following instructions are for building the ufs-weather-model (standalone;
+not the ufs-mrweather app - for the latter, the model is built by the workflow)
+with those libraries installed.
+
+This is separate from NCEPLIBS-external and NCEPLIBS, and details on how to get
+the code are provided here: https://github.com/ufs-community/ufs-weather-model/wiki
+
+After checking out the code and changing to the top-level directory of ufs-weather-model,
+the following commands should suffice to build the model.
+
 
 module purge
 module load ncarenv/1.3

--- a/doc/README_cheyenne_intel.txt
+++ b/doc/README_cheyenne_intel.txt
@@ -34,7 +34,19 @@ make VERBOSE=1 -j2 2>&1 | tee log.make
 make install
 
 
-How to build the ufs-weather-model (standalone; not the ufs-mrweather app - for the latter, the model is built by the workflow) with those libraries installed:
+- END OF THE SETUP INSTRUCTIONS -
+
+
+The following instructions are for building the ufs-weather-model (standalone;
+not the ufs-mrweather app - for the latter, the model is built by the workflow)
+with those libraries installed.
+
+This is separate from NCEPLIBS-external and NCEPLIBS, and details on how to get
+the code are provided here: https://github.com/ufs-community/ufs-weather-model/wiki
+
+After checking out the code and changing to the top-level directory of ufs-weather-model,
+the following commands should suffice to build the model.
+
 
 module purge
 module load ncarenv/1.3

--- a/doc/README_gaea_intel.txt
+++ b/doc/README_gaea_intel.txt
@@ -43,7 +43,19 @@ make VERBOSE=1 -j8 2>&1 | tee log.make
 make install VERBOSE=1 2>&1 | tee log.install
 
 
-How to build the ufs-weather-model (standalone; not the ufs-mrweather app - for the latter, the model is built by the workflow) with those libraries installed:
+- END OF THE SETUP INSTRUCTIONS -
+
+
+The following instructions are for building the ufs-weather-model (standalone;
+not the ufs-mrweather app - for the latter, the model is built by the workflow)
+with those libraries installed.
+
+This is separate from NCEPLIBS-external and NCEPLIBS, and details on how to get
+the code are provided here: https://github.com/ufs-community/ufs-weather-model/wiki
+
+After checking out the code and changing to the top-level directory of ufs-weather-model,
+the following commands should suffice to build the model.
+
 
 module load intel/18.0.3.222
 module unload cray-mpich/7.4.0

--- a/doc/README_hera_gnu.txt
+++ b/doc/README_hera_gnu.txt
@@ -1,0 +1,64 @@
+Setup instructions for NOAA RDHPC Hera using Intel-18.0.5.274
+
+module purge
+module load gnu/9.2.0
+module load openmpi/3.1.4
+module load netcdf/4.7.2
+module use -a /scratch1/BMC/gmtb/software/modulefiles/generic
+module load cmake/3.16.3
+module li
+
+Currently Loaded Modules:
+  1) gnu/9.2.0   2) openmpi/3.1.4   3) netcdf/4.7.2   4) cmake/3.16.3
+
+# Note: HDF5 is in: /apps/spack/linux-centos7-x86_64/gcc-9.2.0/hdf5-1.10.5-uqhakmfhtep2hs3av7xks2s5aey3mve4
+#       also need to correct NETCDF and set NETCDF_FORTRAN
+# Note: ZLIB and PNG are in: /usr/include, /usr/lib64/
+
+export CC=gcc
+export CXX=g++
+export FC=gfortran
+
+export HDF5_ROOT=/apps/spack/linux-centos7-x86_64/gcc-9.2.0/hdf5-1.10.5-uqhakmfhtep2hs3av7xks2s5aey3mve4
+export NETCDF=/apps/spack/linux-centos7-x86_64/gcc-9.2.0/netcdf-c-4.7.2-oha2l67mxurak6ybgej7bohnkfqv5yjs
+export NETCDF_FORTRAN=/apps/spack/linux-centos7-x86_64/gcc-9.2.0/netcdf-fortran-4.5.2-n7v42mkplucx4vtcndykp7iwmjqffilc
+export PNG_ROOT=/usr
+
+mkdir -p /scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0/gnu-9.2.0/openmpi-3.1.4/src
+cd /scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0/gnu-9.2.0/openmpi-3.1.4/src
+
+git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+cd NCEPLIBS-external
+mkdir build && cd build
+# If netCDF is not built, also don't build PNG, because netCDF uses the default (OS) zlib in the search path
+cmake -DBUILD_PNG=OFF -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=/scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0/gnu-9.2.0/openmpi-3.1.4 .. 2>&1 | tee log.cmake
+make VERBOSE=1 -j8 2>&1 | tee log.make
+
+cd /scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0/gnu-9.2.0/openmpi-3.1.4/src
+git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+cd NCEPLIBS
+mkdir build && cd build
+cmake -DEXTERNAL_LIBS_DIR=/scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0/gnu-9.2.0/openmpi-3.1.4 -DCMAKE_INSTALL_PREFIX=/scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0/gnu-9.2.0/openmpi-3.1.4 .. 2>&1 | tee log.cmake
+make VERBOSE=1 -j8 2>&1 | tee log.make
+make install
+
+
+How to build the ufs-weather-model (standalone; not the ufs-mrweather app - for the latter, the model is built by the workflow) with those libraries installed:
+
+module purge
+module load gnu/9.2.0
+module load openmpi/3.1.4
+module load netcdf/4.7.2
+module use -a /scratch1/BMC/gmtb/software/modulefiles/generic
+module load cmake/3.16.3
+module li
+
+export CC=gcc
+export CXX=g++
+export FC=gfortran
+
+module use -a /scratch1/BMC/gmtb/software/modulefiles/gnu-9.2.0/openmpi-3.1.4
+module load  NCEPlibs/1.0.0
+
+export CMAKE_Platform=hera.intel
+./build.sh 2>&1 | tee build.log

--- a/doc/README_hera_gnu.txt
+++ b/doc/README_hera_gnu.txt
@@ -43,7 +43,19 @@ make VERBOSE=1 -j8 2>&1 | tee log.make
 make install
 
 
-How to build the ufs-weather-model (standalone; not the ufs-mrweather app - for the latter, the model is built by the workflow) with those libraries installed:
+- END OF THE SETUP INSTRUCTIONS -
+
+
+The following instructions are for building the ufs-weather-model (standalone;
+not the ufs-mrweather app - for the latter, the model is built by the workflow)
+with those libraries installed.
+
+This is separate from NCEPLIBS-external and NCEPLIBS, and details on how to get
+the code are provided here: https://github.com/ufs-community/ufs-weather-model/wiki
+
+After checking out the code and changing to the top-level directory of ufs-weather-model,
+the following commands should suffice to build the model.
+
 
 module purge
 module load gnu/9.2.0

--- a/doc/README_hera_intel.txt
+++ b/doc/README_hera_intel.txt
@@ -40,7 +40,19 @@ make VERBOSE=1 -j8 2>&1 | tee log.make
 make install
 
 
-How to build the ufs-weather-model (standalone; not the ufs-mrweather app - for the latter, the model is built by the workflow) with those libraries installed:
+- END OF THE SETUP INSTRUCTIONS -
+
+
+The following instructions are for building the ufs-weather-model (standalone;
+not the ufs-mrweather app - for the latter, the model is built by the workflow)
+with those libraries installed.
+
+This is separate from NCEPLIBS-external and NCEPLIBS, and details on how to get
+the code are provided here: https://github.com/ufs-community/ufs-weather-model/wiki
+
+After checking out the code and changing to the top-level directory of ufs-weather-model,
+the following commands should suffice to build the model.
+
 
 module purge
 module load intel/18.0.5.274

--- a/doc/README_hera_intel.txt
+++ b/doc/README_hera_intel.txt
@@ -42,6 +42,7 @@ make install
 
 How to build the ufs-weather-model (standalone; not the ufs-mrweather app - for the latter, the model is built by the workflow) with those libraries installed:
 
+module purge
 module load intel/18.0.5.274
 module load impi/2018.0.4
 module load netcdf/4.7.0

--- a/doc/README_hera_intel_parallel_netcdf.txt
+++ b/doc/README_hera_intel_parallel_netcdf.txt
@@ -51,7 +51,19 @@ make VERBOSE=1 -j8 2>&1 | tee log.make
 make install
 
 
-How to build the ufs-weather-model (standalone; not the ufs-mrweather app - for the latter, the model is built by the workflow) with those libraries installed:
+- END OF THE SETUP INSTRUCTIONS -
+
+
+The following instructions are for building the ufs-weather-model (standalone;
+not the ufs-mrweather app - for the latter, the model is built by the workflow)
+with those libraries installed.
+
+This is separate from NCEPLIBS-external and NCEPLIBS, and details on how to get
+the code are provided here: https://github.com/ufs-community/ufs-weather-model/wiki
+
+After checking out the code and changing to the top-level directory of ufs-weather-model,
+the following commands should suffice to build the model.
+
 
 module purge
 module load intel/18.0.5.274

--- a/doc/README_hera_intel_parallel_netcdf.txt
+++ b/doc/README_hera_intel_parallel_netcdf.txt
@@ -1,0 +1,76 @@
+Setup instructions for NOAA RDHPC Hera using Intel-18.0.5.274
+
+module purge
+module load intel/18.0.5.274
+module load impi/2018.0.4
+
+module use -a /scratch1/NCEPDEV/nems/emc.nemspara/soft/modulefiles
+module load hdf5_parallel/1.10.6
+module load netcdf_parallel/4.7.4
+module load esmf/8.0.0_ParallelNetCDF
+
+module use -a /scratch1/BMC/gmtb/software/modulefiles/generic
+module load cmake/3.16.3
+module li
+
+> Currently Loaded Modules:
+>   1) intel/18.0.5.274   2) impi/2018.0.4   3) hdf5_parallel/1.10.6   4) netcdf_parallel/4.7.4   5) esmf/8.0.0_ParallelNetCDF   6) cmake/3.16.3
+
+# Note: HDF5 is in: /apps/hdf5/1.10.5/intel/18.0.5.274
+# Note: ZLIB and PNG are in: /usr/include, /usr/lib64/
+# Notes:
+#    NETCDF="/scratch1/NCEPDEV/nems/emc.nemspara/soft/netcdf_parallel"
+#    HDF5="/scratch1/NCEPDEV/nems/emc.nemspara/soft/netcdf_parallel"
+#    ESMFMKFILE="/scratch1/NCEPDEV/nems/emc.nemspara/soft/esmf/8.0.0-intel18.0.5.274-impi2018.0.4-netcdf4.7.4_parallel/lib/esmf.mk"
+#    ZLIB and PNG are in: /usr/include, /usr/lib64/
+
+export CC=icc
+export CXX=icpc
+export FC=ifort
+
+export HDF5_ROOT=$HDF5
+export PNG_ROOT=/usr
+export ZLIB_ROOT=/usr
+/scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0-parallel-netcdf/intel-18.0.5.274/impi-2018.0.4/src
+mkdir -p /scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0-parallel-netcdf/intel-18.0.5.274/impi-2018.0.4/src
+cd /scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0-parallel-netcdf/intel-18.0.5.274/impi-2018.0.4/src
+
+git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+cd NCEPLIBS-external
+mkdir build && cd build
+# If netCDF is not built, also don't build PNG, because netCDF uses the default (OS) zlib in the search path
+cmake -DBUILD_ESMF=OFF -DBUILD_PNG=OFF -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=/scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0-parallel-netcdf/intel-18.0.5.274/impi-2018.0.4 .. 2>&1 | tee log.cmake
+make VERBOSE=1 -j8 2>&1 | tee log.make
+
+cd /scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0-parallel-netcdf/intel-18.0.5.274/impi-2018.0.4/src
+git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+cd NCEPLIBS
+mkdir build && cd build
+cmake -DEXTERNAL_LIBS_DIR=/scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0-parallel-netcdf/intel-18.0.5.274/impi-2018.0.4 -DCMAKE_INSTALL_PREFIX=/scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0-parallel-netcdf/intel-18.0.5.274/impi-2018.0.4 .. 2>&1 | tee log.cmake
+make VERBOSE=1 -j8 2>&1 | tee log.make
+make install
+
+
+How to build the ufs-weather-model (standalone; not the ufs-mrweather app - for the latter, the model is built by the workflow) with those libraries installed:
+
+module purge
+module load intel/18.0.5.274
+module load impi/2018.0.4
+
+module use -a /scratch1/NCEPDEV/nems/emc.nemspara/soft/modulefiles
+module load hdf5_parallel/1.10.6
+module load netcdf_parallel/4.7.4
+module load esmf/8.0.0_ParallelNetCDF
+
+module use -a /scratch1/BMC/gmtb/software/modulefiles/generic
+module load cmake/3.16.3
+
+export CC=icc
+export CXX=icpc
+export FC=ifort
+
+module use -a /scratch1/BMC/gmtb/software/modulefiles/intel-18.0.5.274/impi-2018.0.4
+module load NCEPlibs/1.0.0-parallel-netcdf
+
+export CMAKE_Platform=hera.intel
+./build.sh 2>&1 | tee build.log

--- a/doc/README_jet_intel.txt
+++ b/doc/README_jet_intel.txt
@@ -40,7 +40,19 @@ make VERBOSE=1 -j8 2>&1 | tee log.make
 make install
 
 
-How to build the ufs-weather-model (standalone; not the ufs-mrweather app - for the latter, the model is built by the workflow) with those libraries installed:
+- END OF THE SETUP INSTRUCTIONS -
+
+
+The following instructions are for building the ufs-weather-model (standalone;
+not the ufs-mrweather app - for the latter, the model is built by the workflow)
+with those libraries installed.
+
+This is separate from NCEPLIBS-external and NCEPLIBS, and details on how to get
+the code are provided here: https://github.com/ufs-community/ufs-weather-model/wiki
+
+After checking out the code and changing to the top-level directory of ufs-weather-model,
+the following commands should suffice to build the model.
+
 
 module purge
 module load intel/18.0.5.274

--- a/doc/README_macos_clanggfortran.txt
+++ b/doc/README_macos_clanggfortran.txt
@@ -82,7 +82,19 @@ make -j8 2>&1 | tee log.make
 make install 2>&1 | tee log.install
 
 
-How to build the ufs-weather-model (standalone; not the ufs-mrweather app - for the latter, the model is built by the workflow) with those libraries installed:
+- END OF THE SETUP INSTRUCTIONS -
+
+
+The following instructions are for building the ufs-weather-model (standalone;
+not the ufs-mrweather app - for the latter, the model is built by the workflow)
+with those libraries installed.
+
+This is separate from NCEPLIBS-external and NCEPLIBS, and details on how to get
+the code are provided here: https://github.com/ufs-community/ufs-weather-model/wiki
+
+After checking out the code and changing to the top-level directory of ufs-weather-model,
+the following commands should suffice to build the model.
+
 
 export CC=clang-9
 export FC=gfortran-9

--- a/doc/README_macos_gccgfortran.txt
+++ b/doc/README_macos_gccgfortran.txt
@@ -75,7 +75,19 @@ make -j8 2>&1 | tee log.make
 make install 2>&1 | tee log.install
 
 
-How to build the ufs-weather-model (standalone; not the ufs-mrweather app - for the latter, the model is built by the workflow) with those libraries installed:
+- END OF THE SETUP INSTRUCTIONS -
+
+
+The following instructions are for building the ufs-weather-model (standalone;
+not the ufs-mrweather app - for the latter, the model is built by the workflow)
+with those libraries installed.
+
+This is separate from NCEPLIBS-external and NCEPLIBS, and details on how to get
+the code are provided here: https://github.com/ufs-community/ufs-weather-model/wiki
+
+After checking out the code and changing to the top-level directory of ufs-weather-model,
+the following commands should suffice to build the model.
+
 
 export CC=gcc-9
 export FC=gfortran-9

--- a/doc/README_orion_intel.txt
+++ b/doc/README_orion_intel.txt
@@ -44,7 +44,19 @@ make VERBOSE=1 -j8 2>&1 | tee log.make
 make install 2>&1 | tee log.install
 
 
-How to build the ufs-weather-model (standalone; not the ufs-mrweather app - for the latter, the model is built by the workflow) with those libraries installed:
+- END OF THE SETUP INSTRUCTIONS -
+
+
+The following instructions are for building the ufs-weather-model (standalone;
+not the ufs-mrweather app - for the latter, the model is built by the workflow)
+with those libraries installed.
+
+This is separate from NCEPLIBS-external and NCEPLIBS, and details on how to get
+the code are provided here: https://github.com/ufs-community/ufs-weather-model/wiki
+
+After checking out the code and changing to the top-level directory of ufs-weather-model,
+the following commands should suffice to build the model.
+
 
 module purge
 module load intel/2020

--- a/doc/README_redhat_gnu.txt
+++ b/doc/README_redhat_gnu.txt
@@ -81,7 +81,19 @@ make -j8 2>&1 | tee log.make
 make install 2>&1 | tee log.install
 
 
-How to build the ufs-weather-model (standalone; not the ufs-mrweather app - for the latter, the model is built by the workflow) with those libraries installed:
+- END OF THE SETUP INSTRUCTIONS -
+
+
+The following instructions are for building the ufs-weather-model (standalone;
+not the ufs-mrweather app - for the latter, the model is built by the workflow)
+with those libraries installed.
+
+This is separate from NCEPLIBS-external and NCEPLIBS, and details on how to get
+the code are provided here: https://github.com/ufs-community/ufs-weather-model/wiki
+
+After checking out the code and changing to the top-level directory of ufs-weather-model,
+the following commands should suffice to build the model.
+
 
 export CC=gcc
 export CXX=g++

--- a/doc/README_stampede_intel.txt
+++ b/doc/README_stampede_intel.txt
@@ -45,7 +45,19 @@ make VERBOSE=1 -j8 2>&1 | tee log.make
 make install 2>&1 | tee log.install
 
 
-How to build the ufs-weather-model (standalone; not the ufs-mrweather app - for the latter, the model is built by the workflow) with those libraries installed:
+- END OF THE SETUP INSTRUCTIONS -
+
+
+The following instructions are for building the ufs-weather-model (standalone;
+not the ufs-mrweather app - for the latter, the model is built by the workflow)
+with those libraries installed.
+
+This is separate from NCEPLIBS-external and NCEPLIBS, and details on how to get
+the code are provided here: https://github.com/ufs-community/ufs-weather-model/wiki
+
+After checking out the code and changing to the top-level directory of ufs-weather-model,
+the following commands should suffice to build the model.
+
 
 module purge
 #

--- a/doc/README_ubuntu_gnu.txt
+++ b/doc/README_ubuntu_gnu.txt
@@ -83,7 +83,19 @@ make -j8 2>&1 | tee log.make
 make install 2>&1 | tee log.install
 
 
-How to build the ufs-weather-model (standalone; not the ufs-mrweather app - for the latter, the model is built by the workflow) with those libraries installed:
+- END OF THE SETUP INSTRUCTIONS -
+
+
+The following instructions are for building the ufs-weather-model (standalone;
+not the ufs-mrweather app - for the latter, the model is built by the workflow)
+with those libraries installed.
+
+This is separate from NCEPLIBS-external and NCEPLIBS, and details on how to get
+the code are provided here: https://github.com/ufs-community/ufs-weather-model/wiki
+
+After checking out the code and changing to the top-level directory of ufs-weather-model,
+the following commands should suffice to build the model.
+
 
 export CC=gcc-8
 export CXX=g++-8


### PR DESCRIPTION
This PR is a documentation change only. Support for Hera with newly added GNU compilers, has been tested with the ufs-v1.0.0 tags of NCEPLIBS-external and NCEPLIBS.

Also included is a setup log for Hera with Intel when using the newly created parallel NetCDF libraries (used by the GFSv16 global workflow), and an update of the macOS Travis CI script.

Further, this PR contains an update of all `doc/README_*.txt` files to make clear in the instructions when the NCEPLIBS-external/NCEPLIBS build is completed and how to proceed.