### PR TITLE
Update build instructions for hera.gnu and jet.intel

### DIFF
--- a/doc/README_hera_gnu.txt
+++ b/doc/README_hera_gnu.txt
@@ -2,45 +2,33 @@ Setup instructions for NOAA RDHPC Hera using Intel-18.0.5.274
 
 module purge
 module load gnu/9.2.0
-module load openmpi/3.1.4
-module load netcdf/4.7.2
-module use -a /scratch1/BMC/gmtb/software/modulefiles/generic
-module load cmake/3.16.3
-module li
+module use -a /scratch1/BMC/gmtb/software/modulefiles/gnu-9.2.0/mpich-3.3.2
+module load mpich/3.3.2
+module load cmake/3.16.1
 
-Currently Loaded Modules:
-  1) gnu/9.2.0   2) openmpi/3.1.4   3) netcdf/4.7.2   4) cmake/3.16.3
-
-# Note: HDF5 is in: /apps/spack/linux-centos7-x86_64/gcc-9.2.0/hdf5-1.10.5-uqhakmfhtep2hs3av7xks2s5aey3mve4
-#       also need to correct NETCDF and set NETCDF_FORTRAN
-# Note: ZLIB and PNG are in: /usr/include, /usr/lib64/
+> Currently Loaded Modules:
+>   1) gnu/9.2.0   2) mpich/3.3.2   3) cmake/3.16.1
 
 export CC=gcc
 export CXX=g++
 export FC=gfortran
 
-export HDF5_ROOT=/apps/spack/linux-centos7-x86_64/gcc-9.2.0/hdf5-1.10.5-uqhakmfhtep2hs3av7xks2s5aey3mve4
-export NETCDF=/apps/spack/linux-centos7-x86_64/gcc-9.2.0/netcdf-c-4.7.2-oha2l67mxurak6ybgej7bohnkfqv5yjs
-export NETCDF_FORTRAN=/apps/spack/linux-centos7-x86_64/gcc-9.2.0/netcdf-fortran-4.5.2-n7v42mkplucx4vtcndykp7iwmjqffilc
-export PNG_ROOT=/usr
-
-mkdir -p /scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0/gnu-9.2.0/openmpi-3.1.4/src
-cd /scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0/gnu-9.2.0/openmpi-3.1.4/src
+mkdir -p /scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0/gnu-9.2.0/mpich-3.3.2/src
+cd /scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0/gnu-9.2.0/mpich-3.3.2/src
 
 git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
-# If netCDF is not built, also don't build PNG, because netCDF uses the default (OS) zlib in the search path
-cmake -DBUILD_PNG=OFF -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=/scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0/gnu-9.2.0/openmpi-3.1.4 .. 2>&1 | tee log.cmake
+cmake -DBUILD_MPI=OFF -DCMAKE_INSTALL_PREFIX=/scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0/gnu-9.2.0/mpich-3.3.2 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
 
-cd /scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0/gnu-9.2.0/openmpi-3.1.4/src
+cd /scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0/gnu-9.2.0/mpich-3.3.2/src
 git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
-mkdir build && cd build
-cmake -DEXTERNAL_LIBS_DIR=/scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0/gnu-9.2.0/openmpi-3.1.4 -DCMAKE_INSTALL_PREFIX=/scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0/gnu-9.2.0/openmpi-3.1.4 .. 2>&1 | tee log.cmake
+rm -fr build && mkdir build && cd build
+cmake -DEXTERNAL_LIBS_DIR=/scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0/gnu-9.2.0/mpich-3.3.2 -DCMAKE_INSTALL_PREFIX=/scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0/gnu-9.2.0/mpich-3.3.2 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
-make install
+make install 2>&1 | tee log.install
 
 
 - END OF THE SETUP INSTRUCTIONS -
@@ -59,17 +47,15 @@ the following commands should suffice to build the model.
 
 module purge
 module load gnu/9.2.0
-module load openmpi/3.1.4
-module load netcdf/4.7.2
-module use -a /scratch1/BMC/gmtb/software/modulefiles/generic
-module load cmake/3.16.3
+module use -a /scratch1/BMC/gmtb/software/modulefiles/gnu-9.2.0/mpich-3.3.2
+module load mpich/3.3.2
+module load cmake/3.16.1
 module li
 
 export CC=gcc
 export CXX=g++
 export FC=gfortran
 
-module use -a /scratch1/BMC/gmtb/software/modulefiles/gnu-9.2.0/openmpi-3.1.4
 module load  NCEPlibs/1.0.0
 
 export CMAKE_Platform=hera.intel

--- a/doc/README_jet_intel.txt
+++ b/doc/README_jet_intel.txt
@@ -4,12 +4,11 @@ module purge
 module load intel/18.0.5.274
 module load impi/2018.4.274
 module load netcdf/4.7.0
-module use -a /lfs3/projects/hfv3gfs/GMTB/modulefiles/generic
-module load cmake/3.16.4
+module load cmake/3.16.1
 module li
 
 > Currently Loaded Modules:
->  1) intel/18.0.5.274   2) impi/2018.4.274   3) netcdf/4.7.0   4) cmake/3.16.4
+>  1) intel/18.0.5.274   2) impi/2018.4.274   3) netcdf/4.7.0   4) cmake/3.16.1
 
 export CC=icc
 export FC=ifort
@@ -21,21 +20,21 @@ export CXX=icpc
 export HDF5_ROOT=/apps/hdf5/1.10.5/intel/18.0.5.274
 export PNG_ROOT=/usr
 
-mkdir -p /lfs3/projects/hfv3gfs/GMTB/NCEPlibs-ufs-v1.0.0/intel-18.0.5.274/impi-2018.4.274/src
-cd /lfs3/projects/hfv3gfs/GMTB/NCEPlibs-ufs-v1.0.0/intel-18.0.5.274/impi-2018.4.274/src
+mkdir -p /lfs4/HFIP/hfv3gfs/software/NCEPlibs-ufs-v1.0.0/intel-18.0.5.274/impi-2018.4.274/src
+cd /lfs4/HFIP/hfv3gfs/software/NCEPlibs-ufs-v1.0.0/intel-18.0.5.274/impi-2018.4.274/src
 
 git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
 # If netCDF is not built, also don't build PNG, because netCDF uses the default (OS) zlib in the search path
-cmake -DBUILD_PNG=OFF -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=/lfs3/projects/hfv3gfs/GMTB/NCEPlibs-ufs-v1.0.0/intel-18.0.5.274/impi-2018.4.274 .. 2>&1 | tee log.cmake
+cmake -DBUILD_PNG=OFF -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=/lfs4/HFIP/hfv3gfs/software/NCEPlibs-ufs-v1.0.0/intel-18.0.5.274/impi-2018.4.274 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
 
-cd /lfs3/projects/hfv3gfs/GMTB/NCEPlibs-ufs-v1.0.0/intel-18.0.5.274/impi-2018.4.274/src
+cd /lfs4/HFIP/hfv3gfs/software/NCEPlibs-ufs-v1.0.0/intel-18.0.5.274/impi-2018.4.274/src
 git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build && cd build
-cmake -DEXTERNAL_LIBS_DIR=/lfs3/projects/hfv3gfs/GMTB/NCEPlibs-ufs-v1.0.0/intel-18.0.5.274/impi-2018.4.274 -DCMAKE_INSTALL_PREFIX=/lfs3/projects/hfv3gfs/GMTB/NCEPlibs-ufs-v1.0.0/intel-18.0.5.274/impi-2018.4.274 .. 2>&1 | tee log.cmake
+cmake -DEXTERNAL_LIBS_DIR=/lfs4/HFIP/hfv3gfs/software/NCEPlibs-ufs-v1.0.0/intel-18.0.5.274/impi-2018.4.274 -DCMAKE_INSTALL_PREFIX=/lfs4/HFIP/hfv3gfs/software/NCEPlibs-ufs-v1.0.0/intel-18.0.5.274/impi-2018.4.274 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
 make install
 
@@ -58,15 +57,14 @@ module purge
 module load intel/18.0.5.274
 module load impi/2018.4.274
 module load netcdf/4.7.0
-module use -a /lfs3/projects/hfv3gfs/GMTB/modulefiles/generic
-module load cmake/3.16.4
+module load cmake/3.16.1
 
 export CC=icc
 export FC=ifort
 export CXX=icpc
 
-module use -a /lfs3/projects/hfv3gfs/GMTB/modulefiles/intel-18.0.5.274/impi-2018.4.274
-module load  NCEPlibs/1.0.0
+module use -a /lfs4/HFIP/hfv3gfs/software/modulefiles/intel-18.0.5.274/impi-2018.4.274
+module load NCEPlibs/1.0.0
 
 export CMAKE_Platform=jet.intel
 ./build.sh 2>&1 | tee build.log


### PR DESCRIPTION
Update build instructions for hera.gnu and jet.intel following filesystem and modules environment changes.

Tested on both systems.