### PR TITLE
Final documentatiton update for MRW v.1.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It includes the following libraries:
 | libpng          | libpng-1.6.35                                              |
 | libjpeg         | jpeg-9.1                                                   |
 | Jasper          | jasper-2.0.16                                              |
-| WGRIB2          | wgrib-2.0.8                                                |
+| WGRIB2          | NCEPLIBS-wgrib2 ufs-v1.1.0                                 |
 | ESMF            | esmf-8.0.0                                                 |
 
 ## Building, Requirements, Troubleshooting, Support
@@ -39,7 +39,7 @@ For building NCEPLIBS-external, use `/full_path_to_where_you_installed_cmake/bin
 | Compiler vendor | Supported (tested) versions                                |
 |-----------------|------------------------------------------------------------|
 | Intel           | 18.0.3.222, 18.0.5.274, 19.0.2.187, 19.0.5.281, 19.1.0.166 |
-| GNU             | 8.3.0, 9.1.0, 9.2.0                                        |
+| GNU             | 8.3.0, 9.1.0, 9.2.0, 10.2.0                                |
 
 3. A supported MPI library unless installed as part of NCEPLIBS-external, see table below. Other versions may work, in particular if close to the versions listed below. It is recommended to compile the MPI library with the same compilers used to compile NCEPLIBS-external.
 
@@ -82,18 +82,14 @@ Pre-configured systems do have existing installations of NCEPLIBS-external and N
 ### Get and Build the Code
 
 ```
-git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+git clone -b ufs-v1.1.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build
 cd build
 cmake -DCMAKE_INSTALL_PREFIX=INSERT_PATH_HERE ..
 make <-jx>
 ```
-If `-DCMAKE_INSTALL_PREFIX=` is omitted, the libraries will be installed in directory `install` underneath the `build` directory. The optional argument `<-jx>` speeds up the build process by using `x` parallel compile tasks. When static linking is the default option on a given system (e.g. Cray), add
-```
--DSTATIC_IS_DEFAULT=ON
-```
-to the `cmake` call.
+If `-DCMAKE_INSTALL_PREFIX=` is omitted, the libraries will be installed in directory `install` underneath the `build` directory. The optional argument `<-jx>` speeds up the build process by using `x` parallel compile tasks.
 
 By default, NCEPLIBS-external will build and install all libraries listed above except the optional CMake (see next section when this is needed). This is primarily targeted for users who are setting up their own workstations in order to get a consistent software stack. It is important that the MPI wrappers use the same compiler that is used to compile the other external libraries, the NCEP libraries and any UFS application that depends on those. 
 

--- a/doc/README_cheyenne_gnu.txt
+++ b/doc/README_cheyenne_gnu.txt
@@ -16,20 +16,20 @@ export CC=mpicc
 export FC=mpif90
 export CXX=mpicxx
 
-mkdir -p /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0/gnu-8.3.0/mpt-2.19/src
-cd /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0/gnu-8.3.0/mpt-2.19/src
+mkdir -p /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.1.0/gnu-8.3.0/mpt-2.19/src
+cd /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.1.0/gnu-8.3.0/mpt-2.19/src
 
-git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+git clone -b ufs-v1.1.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
-cmake -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DBUILD_PNG=OFF -DCMAKE_INSTALL_PREFIX=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0/gnu-8.3.0/mpt-2.19 .. 2>&1 | tee log.cmake
+cmake -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DBUILD_PNG=OFF -DCMAKE_INSTALL_PREFIX=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.1.0/gnu-8.3.0/mpt-2.19 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j2 2>&1 | tee log.make
 
-cd /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0/gnu-8.3.0/mpt-2.19/src
-git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+cd /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.1.0/gnu-8.3.0/mpt-2.19/src
+git clone -b ufs-v1.1.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build && cd build
-cmake -DEXTERNAL_LIBS_DIR=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0/gnu-8.3.0/mpt-2.19 -DCMAKE_INSTALL_PREFIX=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0/gnu-8.3.0/mpt-2.19 .. 2>&1 | tee log.cmake
+cmake -DEXTERNAL_LIBS_DIR=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.1.0/gnu-8.3.0/mpt-2.19 -DCMAKE_INSTALL_PREFIX=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.1.0/gnu-8.3.0/mpt-2.19 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j2 2>&1 | tee log.make
 make install
 
@@ -61,7 +61,7 @@ export FC=mpif90
 export CXX=mpicxx
 
 module use -a /glade/p/ral/jntp/GMTB/tools/modulefiles/gnu-8.3.0/mpt-2.19
-module load  NCEPlibs/1.0.0
+module load NCEPlibs/1.1.0
 
 export CMAKE_Platform=cheyenne.gnu
 ./build.sh 2>&1 | tee build.log

--- a/doc/README_cheyenne_intel.txt
+++ b/doc/README_cheyenne_intel.txt
@@ -16,20 +16,20 @@ export CC=mpicc
 export FC=mpif90
 export CXX=mpicxx
 
-mkdir -p /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0/intel-19.0.5/mpt-2.19/src
-cd /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0/intel-19.0.5/mpt-2.19/src
+mkdir -p /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.1.0/intel-19.0.5/mpt-2.19/src
+cd /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.1.0/intel-19.0.5/mpt-2.19/src
 
-git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+git clone -b ufs-v1.1.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
-cmake -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DBUILD_PNG=OFF -DCMAKE_INSTALL_PREFIX=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0/intel-19.0.5/mpt-2.19 .. 2>&1 | tee log.cmake
+cmake -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DBUILD_PNG=OFF -DCMAKE_INSTALL_PREFIX=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.1.0/intel-19.0.5/mpt-2.19 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j2 2>&1 | tee log.make
 
-cd /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0/intel-19.0.5/mpt-2.19/src/
-git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+cd /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.1.0/intel-19.0.5/mpt-2.19/src/
+git clone -b ufs-v1.1.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build && cd build
-cmake -DEXTERNAL_LIBS_DIR=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0/intel-19.0.5/mpt-2.19 -DCMAKE_INSTALL_PREFIX=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.0.0/intel-19.0.5/mpt-2.19 .. 2>&1 | tee log.cmake
+cmake -DEXTERNAL_LIBS_DIR=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.1.0/intel-19.0.5/mpt-2.19 -DCMAKE_INSTALL_PREFIX=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.1.0/intel-19.0.5/mpt-2.19 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j2 2>&1 | tee log.make
 make install
 
@@ -61,7 +61,7 @@ export FC=mpif90
 export CXX=mpicxx
 
 module use -a /glade/p/ral/jntp/GMTB/tools/modulefiles/intel-19.0.5/mpt-2.19
-module load  NCEPlibs/1.0.0
+module load NCEPlibs/1.1.0
 
 export CMAKE_Platform=cheyenne.intel
 ./build.sh 2>&1 | tee build.log

--- a/doc/README_gaea_intel.txt
+++ b/doc/README_gaea_intel.txt
@@ -1,44 +1,43 @@
-Setup instructions for NOAA RDHPC Gaea using Cray Intel-18.0.3.222
+Setup instructions for NOAA RDHPC Gaea using Cray Intel-19.0.5.281
 
-module load intel/18.0.3.222
-module unload cray-mpich/7.4.0
-module load cray-mpich/7.7.3
+module load intel/19.0.5.281
+module unload cray-mpich
+module load cray-mpich/7.7.11
 module unload cray-netcdf
-module use -a /lustre/f2/pdata/esrl/gsd/ufs/modules/modulefiles/generic
-module load cmake/3.16.4
+module load cmake/3.17.0
 module li
 
 > Currently Loaded Modulefiles:
->   1) modules/3.2.10.5                                7) udreg/2.3.2-6.0.6.0_15.18__g5196236.ari        13) job/2.2.3-6.0.6.0_9.47__g6c4e934.ari           19) craype-broadwell                               25) hpcrpt/noaa-3
->   2) eproxy/2.0.22-6.0.6.0_5.1__g1ebe45c.ari         8) ugni/6.0.14-6.0.6.0_18.12__g777707d.ari        14) dvs/2.7_2.2.96-6.0.6.1_10.6__g9b73f30          20) CmrsEnv                                        26) cmake/3.16.4
->   3) intel/18.0.3.222                                9) pmi/5.0.10-1.0000.11050.0.0.ari                15) alps/6.6.0-6.0.6.0_35.25__gd0a1ab9.ari         21) TimeZoneEDT                                    27) cray-mpich/7.7.3
->   4) craype-network-aries                           10) dmapp/7.1.1-6.0.6.0_51.37__g5a674e0.ari        16) rca/2.2.18-6.0.6.0_19.14__g2aa4f39.ari         22) globus_toolkit/6.0.1470089956
->   5) craype/2.5.5                                   11) gni-headers/5.0.12-6.0.6.0_3.26__g527b6e1.ari  17) atp/2.0.2                                      23) globus/6.0.1470089956
->   6) cray-libsci/16.06.1                            12) xpmem/2.2.14-6.0.6.1_5.8__g34333c9.ari         18) PrgEnv-intel/6.0.3                             24) DefApps
+>   1) modules/3.2.11.4                                 7) udreg/2.3.2-7.0.2.1_2.15__g8175d3d.ari          13) job/2.2.4-7.0.2.1_2.18__g36b56f4.ari            19) PrgEnv-intel/6.0.5                              25) darshan/3.2.1
+>   2) eproxy/2.0.24-7.0.2.1_2.20__g8e04b33.ari         8) ugni/6.0.14.0-7.0.2.1_3.15__ge78e5b0.ari        14) dvs/2.12_2.2.164-7.0.2.1_3.8__g1afc88eb         20) craype-broadwell                                26) DefApps
+>   3) intel/19.0.5.281                                 9) pmi/5.0.15                                      15) alps/6.6.59-7.0.2.1_3.7__g872a8d62.ari          21) cray-mpich/7.7.11                               27) hpcrpt/noaa-3
+>   4) craype-network-aries                            10) dmapp/7.1.1-7.0.2.1_2.19__g38cf134.ari          16) rca/2.2.20-7.0.2.1_2.20__g8e3fb5b.ari           22) CmrsEnv                                         28) cmake/3.17.0
+>   5) craype/2.6.3                                    11) gni-headers/5.0.12.0-7.0.2.1_2.4__g3b1768f.ari  17) atp/2.1.3                                       23) TimeZoneEDT
+>   6) cray-libsci/19.06.1                             12) xpmem/2.2.20-7.0.2.1_2.15__g87eb960.ari         18) perftools-base/7.1.3                            24) globus-toolkit/6.0.17
 
 # Need to use MPI wrappers in order to find pre-installed Cray MPICH
 export CC=cc
 export FC=ftn
 export CXX=CC
-export MPI_ROOT=/opt/cray/pe/mpt/7.7.3/gni/mpich-intel/16.0
+export MPI_ROOT=/opt/cray/pe/mpt/7.7.11/gni/mpich-intel/16.0
 
-mkdir -p /lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0/intel-18.0.3.222/cray-mpich-7.7.3/src
+mkdir -p /lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.1.0/intel-19.0.5.281/cray-mpich-7.7.11/src
 
-cd /lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0/intel-18.0.3.222/cray-mpich-7.7.3/src
+cd /lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.1.0/intel-19.0.5.281/cray-mpich-7.7.11/src
 # Note: remote access severely limited on gaea; need to do the git clone on a remote system and rsync to gaea
-git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+git clone -b ufs-v1.1.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
-cmake -DBUILD_MPI=OFF -DSTATIC_IS_DEFAULT=ON -DCMAKE_INSTALL_PREFIX=/lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0/intel-18.0.3.222/cray-mpich-7.7.3 .. 2>&1 | tee log.cmake
+cmake -DBUILD_MPI=OFF -DCMAKE_INSTALL_PREFIX=/lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.1.0/intel-19.0.5.281/cray-mpich-7.7.11 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
 # no make install necessary
 
-cd /lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0/intel-18.0.3.222/cray-mpich-7.7.3/src
+cd /lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.1.0/intel-19.0.5.281/cray-mpich-7.7.11/src
 # Note: remote access severely limited on gaea; need to do the git clone on a remote system and rsync to gaea
-git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+git clone -b ufs-v1.1.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build && cd build
-cmake -DEXTERNAL_LIBS_DIR=/lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0/intel-18.0.3.222/cray-mpich-7.7.3 -DCMAKE_INSTALL_PREFIX=/lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.0.0/intel-18.0.3.222/cray-mpich-7.7.3 -DSTATIC_IS_DEFAULT=ON .. 2>&1 | tee log.cmake
+cmake -DEXTERNAL_LIBS_DIR=/lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.1.0/intel-19.0.5.281/cray-mpich-7.7.11 -DCMAKE_INSTALL_PREFIX=/lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.1.0/intel-19.0.5.281/cray-mpich-7.7.11 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
 make install VERBOSE=1 2>&1 | tee log.install
 
@@ -57,16 +56,15 @@ After checking out the code and changing to the top-level directory of ufs-weath
 the following commands should suffice to build the model.
 
 
-module load intel/18.0.3.222
-module unload cray-mpich/7.4.0
-module load cray-mpich/7.7.3
+module load intel/19.0.5.281
+module unload cray-mpich
+module load cray-mpich/7.7.11
 module unload cray-netcdf
+module load cmake/3.17.0
+module li
 
-module use -a /lustre/f2/pdata/esrl/gsd/ufs/modules/modulefiles/generic
-module load cmake/3.16.4
-
-module use -a /lustre/f2/pdata/esrl/gsd/ufs/modules/modulefiles/intel-18.0.3.222
-module load NCEPlibs/1.0.0
+module use -a /lustre/f2/pdata/esrl/gsd/ufs/modules/modulefiles/intel-19.0.5.281/cray-mpich-7.7.11
+module load NCEPlibs/1.1.0
 
 export CMAKE_Platform=gaea.intel
 export CMAKE_C_COMPILER=cc

--- a/doc/README_hera_gnu.txt
+++ b/doc/README_hera_gnu.txt
@@ -1,4 +1,4 @@
-Setup instructions for NOAA RDHPC Hera using Intel-18.0.5.274
+Setup instructions for NOAA RDHPC Hera using gnu-9.2.0
 
 module purge
 module load gnu/9.2.0

--- a/doc/README_hera_intel.txt
+++ b/doc/README_hera_intel.txt
@@ -4,12 +4,11 @@ module purge
 module load intel/18.0.5.274
 module load impi/2018.0.4
 module load netcdf/4.7.0
-module use -a /scratch1/BMC/gmtb/software/modulefiles/generic
-module load cmake/3.16.3
+module load cmake/3.16.1
 module li
 
 > Currently Loaded Modules:
->  1) intel/18.0.5.274   2) impi/2018.0.4   3) netcdf/4.7.0   4) cmake/3.16.3
+>  1) intel/18.0.5.274   2) impi/2018.0.4   3) netcdf/4.7.0   4) cmake/3.16.1
 
 # Note: HDF5 is in: /apps/hdf5/1.10.5/intel/18.0.5.274
 # Note: ZLIB and PNG are in: /usr/include, /usr/lib64/
@@ -21,21 +20,21 @@ export FC=ifort
 export HDF5_ROOT=/apps/hdf5/1.10.5/intel/18.0.5.274
 export PNG_ROOT=/usr
 
-mkdir -p /scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0/intel-18.0.5.274/impi-2018.0.4/src
-cd /scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0/intel-18.0.5.274/impi-2018.0.4/src
+mkdir -p /scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.1.0/intel-18.0.5.274/impi-2018.0.4/src
+cd /scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.1.0/intel-18.0.5.274/impi-2018.0.4/src
 
-git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+git clone -b ufs-v1.1.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
 # If netCDF is not built, also don't build PNG, because netCDF uses the default (OS) zlib in the search path
-cmake -DBUILD_PNG=OFF -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=/scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0/intel-18.0.5.274/impi-2018.0.4 .. 2>&1 | tee log.cmake
+cmake -DBUILD_PNG=OFF -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=/scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.1.0/intel-18.0.5.274/impi-2018.0.4 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
 
-cd /scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0/intel-18.0.5.274/impi-2018.0.4/src
-git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+cd /scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.1.0/intel-18.0.5.274/impi-2018.0.4/src
+git clone -b ufs-v1.1.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build && cd build
-cmake -DEXTERNAL_LIBS_DIR=/scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0/intel-18.0.5.274/impi-2018.0.4 -DCMAKE_INSTALL_PREFIX=/scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.0.0/intel-18.0.5.274/impi-2018.0.4 .. 2>&1 | tee log.cmake
+cmake -DEXTERNAL_LIBS_DIR=/scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.1.0/intel-18.0.5.274/impi-2018.0.4 -DCMAKE_INSTALL_PREFIX=/scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.1.0/intel-18.0.5.274/impi-2018.0.4 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
 make install
 
@@ -58,15 +57,14 @@ module purge
 module load intel/18.0.5.274
 module load impi/2018.0.4
 module load netcdf/4.7.0
-module use -a /scratch1/BMC/gmtb/software/modulefiles/generic
-module load cmake/3.16.3
+module load cmake/3.16.1
 
 export CC=icc
 export CXX=icpc
 export FC=ifort
 
 module use -a /scratch1/BMC/gmtb/software/modulefiles/intel-18.0.5.274/impi-2018.0.4
-module load  NCEPlibs/1.0.0
+module load  NCEPlibs/1.1.0
 
 export CMAKE_Platform=hera.intel
 ./build.sh 2>&1 | tee build.log

--- a/doc/README_jet_intel.txt
+++ b/doc/README_jet_intel.txt
@@ -20,21 +20,21 @@ export CXX=icpc
 export HDF5_ROOT=/apps/hdf5/1.10.5/intel/18.0.5.274
 export PNG_ROOT=/usr
 
-mkdir -p /lfs4/HFIP/hfv3gfs/software/NCEPlibs-ufs-v1.0.0/intel-18.0.5.274/impi-2018.4.274/src
-cd /lfs4/HFIP/hfv3gfs/software/NCEPlibs-ufs-v1.0.0/intel-18.0.5.274/impi-2018.4.274/src
+mkdir -p /lfs4/HFIP/hfv3gfs/software/NCEPlibs-ufs-v1.1.0/intel-18.0.5.274/impi-2018.4.274/src
+cd /lfs4/HFIP/hfv3gfs/software/NCEPlibs-ufs-v1.1.0/intel-18.0.5.274/impi-2018.4.274/src
 
-git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+git clone -b ufs-v1.1.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
 # If netCDF is not built, also don't build PNG, because netCDF uses the default (OS) zlib in the search path
-cmake -DBUILD_PNG=OFF -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=/lfs4/HFIP/hfv3gfs/software/NCEPlibs-ufs-v1.0.0/intel-18.0.5.274/impi-2018.4.274 .. 2>&1 | tee log.cmake
+cmake -DBUILD_PNG=OFF -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=/lfs4/HFIP/hfv3gfs/software/NCEPlibs-ufs-v1.1.0/intel-18.0.5.274/impi-2018.4.274 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
 
-cd /lfs4/HFIP/hfv3gfs/software/NCEPlibs-ufs-v1.0.0/intel-18.0.5.274/impi-2018.4.274/src
-git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+cd /lfs4/HFIP/hfv3gfs/software/NCEPlibs-ufs-v1.1.0/intel-18.0.5.274/impi-2018.4.274/src
+git clone -b ufs-v1.1.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build && cd build
-cmake -DEXTERNAL_LIBS_DIR=/lfs4/HFIP/hfv3gfs/software/NCEPlibs-ufs-v1.0.0/intel-18.0.5.274/impi-2018.4.274 -DCMAKE_INSTALL_PREFIX=/lfs4/HFIP/hfv3gfs/software/NCEPlibs-ufs-v1.0.0/intel-18.0.5.274/impi-2018.4.274 .. 2>&1 | tee log.cmake
+cmake -DEXTERNAL_LIBS_DIR=/lfs4/HFIP/hfv3gfs/software/NCEPlibs-ufs-v1.1.0/intel-18.0.5.274/impi-2018.4.274 -DCMAKE_INSTALL_PREFIX=/lfs4/HFIP/hfv3gfs/software/NCEPlibs-ufs-v1.1.0/intel-18.0.5.274/impi-2018.4.274 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
 make install
 
@@ -64,7 +64,7 @@ export FC=ifort
 export CXX=icpc
 
 module use -a /lfs4/HFIP/hfv3gfs/software/modulefiles/intel-18.0.5.274/impi-2018.4.274
-module load NCEPlibs/1.0.0
+module load NCEPlibs/1.1.0
 
 export CMAKE_Platform=jet.intel
 ./build.sh 2>&1 | tee build.log

--- a/doc/README_macos_clanggfortran.txt
+++ b/doc/README_macos_clanggfortran.txt
@@ -1,6 +1,6 @@
-Setup instructions for macOS Mojave or Catalina using clang-9.0.0 + gfortran-9.2.0
+Setup instructions for macOS Mojave or Catalina using clang-10.0.0 + gfortran-10.2.0
 
-The following instructions were tested on a clean macOS systems (Mojave 1.14.6 and Catalina 10.15.2).
+The following instructions were tested on a clean macOS systems (Mojave 10.14.6 and Catalina 10.15.6).
 Homebrew is used to install the LLVM (clang+clang++) and GNU (gcc+gfortran) compilers. Note that the export statements
 are required for the subsequent steps, as well as for building NCEPLIBS-external, NCEPLIBS and UFS applications.
 
@@ -16,39 +16,41 @@ open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10
 
 (2) Create directories
 sudo su
-mkdir /usr/local/ufs-release-v1
-chown YOUR_USERNAME:YOUR_GROUPNAME /usr/local/ufs-release-v1
+mkdir /usr/local/ufs-release-v1.1.0
+chown YOUR_USERNAME:YOUR_GROUPNAME /usr/local/ufs-release-v1.1.0
 exit
-cd /usr/local/ufs-release-v1
+cd /usr/local/ufs-release-v1.1.0
 mkdir src
 
-(3) Install gcc-9.2.0/gfortran-9.2.0
+(3) Install gcc-10.2.0/gfortran-10.2.0
 
-brew install gcc@9
+brew install gcc@10
 
-(4) Install clang-9.0.0/clang++-9.0.0
+(4) Install clang-10.0.0/clang++-10.0.0
 
-brew install llvm@9
+brew install llvm@10
 
 export PATH="/usr/local/opt/llvm/bin:$PATH"
 export LD_LIBRARY_PATH="/usr/local/opt/llvm/lib:$LD_LIBRARY_PATH"
 
-export CC=clang-9
-export FC=gfortran-9
-export CXX=clang++-9
+export CC=clang
+export FC=gfortran
+export CXX=clang++
 
-(5) Install wget-0.20.1
+(5) Install wget-1.20.3
 
 brew install wget
 
-(6) Install cmake-3.16.2
+(6) Install cmake-3.18.1
 
 brew install cmake
 
-(7) Install coreutils-8.31 (required later for running the UFS models)
+(7) Install coreutils-8.32 (required later for running the UFS models)
+
 brew install coreutils
 
 (8) Install pkg-config-0.29.2
+
 brew install pkg-config
 
 2. Install missing external libraries from NCEPLIBS-external
@@ -57,11 +59,11 @@ The user is referred to the top-level README.md for more detailed instructions o
 NCEPLIBS-external and configure it (e.g., how to turn off building certain packages such as MPI etc).
 The default configuration assumes that all dependencies are built and installed: MPI, netCDF, ...
 
-cd /usr/local/ufs-release-v1/src
-git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+cd /usr/local/ufs-release-v1.1.0/src
+git clone -b ufs-v1.1.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
-cmake -DCMAKE_INSTALL_PREFIX=/usr/local/ufs-release-v1 .. 2>&1 | tee log.cmake
+cmake -DCMAKE_INSTALL_PREFIX=/usr/local/ufs-release-v1.1.0 .. 2>&1 | tee log.cmake
 make -j8 2>&1 | tee log.make
 # no make install needed
 
@@ -72,12 +74,12 @@ The user is referred to the top-level README.md of the NCEPLIBS GitHub repositor
 and build NCEPLIBS. The default configuration assumes that all dependencies were built
 by NCEPLIBS-external as described above.
 
-cd /usr/local/ufs-release-v1/src
-git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+cd /usr/local/ufs-release-v1.1.0/src
+git clone -b ufs-v1.1.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build
 cd build
-cmake -DCMAKE_INSTALL_PREFIX=/usr/local/ufs-release-v1 -DEXTERNAL_LIBS_DIR=/usr/local/ufs-release-v1 .. 2>&1 | tee log.cmake
+cmake -DCMAKE_INSTALL_PREFIX=/usr/local/ufs-release-v1.1.0 -DEXTERNAL_LIBS_DIR=/usr/local/ufs-release-v1.1.0 .. 2>&1 | tee log.cmake
 make -j8 2>&1 | tee log.make
 make install 2>&1 | tee log.install
 
@@ -102,7 +104,7 @@ export CXX=clang++-9
 export PATH="/usr/local/opt/llvm/bin:$PATH"
 export LD_LIBRARY_PATH="/usr/local/opt/llvm/lib:$LD_LIBRARY_PATH"
 ulimit -S -s unlimited
-. /usr/local/ufs-release-v1/bin/setenv_nceplibs.sh
+. /usr/local/ufs-release-v1.1.0/bin/setenv_nceplibs.sh
 export CMAKE_Platform=macosx.gnu
 ./build.sh 2>&1 | tee build.log
 

--- a/doc/README_macos_gccgfortran.txt
+++ b/doc/README_macos_gccgfortran.txt
@@ -1,4 +1,4 @@
-Setup instructions for macOS Mojave or Catalina using gcc-9.2.0 + gfortran-9.2.0
+Setup instructions for macOS Mojave or Catalina using gcc-10.2.0 + gfortran-10.2.0
 
 The following instructions were tested on a clean macOS systems (Mojave 1.14.6 and Catalina 10.15.2).
 Homebrew is used to install the GNU (gcc+gfortran) compilers. Note that the export statements are
@@ -16,32 +16,34 @@ open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10
 
 (2) Create directories
 sudo su
-mkdir /usr/local/ufs-release-v1
-chown YOUR_USERNAME:YOUR_GROUPNAME /usr/local/ufs-release-v1
+mkdir /usr/local/ufs-release-v1.1.0
+chown YOUR_USERNAME:YOUR_GROUPNAME /usr/local/ufs-release-v1.1.0
 exit
-cd /usr/local/ufs-release-v1
+cd /usr/local/ufs-release-v1.1.0
 mkdir src
 
-(3) Install gcc-9.2.0/gfortran-9.2.0
+(3) Install gcc-10.2.0/gfortran-10.2.0
 
-brew install gcc@9
+brew install gcc@10
 
-export CC=gcc-9
-export FC=gfortran-9
-export CXX=g++-9
+export CC=gcc-10
+export FC=gfortran-10
+export CXX=g++-10
 
-(4) Install wget-0.20.1
+(4) Install wget-1.20.3
 
 brew install wget
 
-(5) Install cmake-3.16.2
+(5) Install cmake-3.18.1
 
 brew install cmake
 
-(6) Install coreutils-8.31 (required later for running the UFS models)
+(6) Install coreutils-8.32 (required later for running the UFS models)
+
 brew install coreutils
 
 (7) Install pkg-config-0.29.2
+
 brew install pkg-config
 
 2. Install missing external libraries from NCEPLIBS-external
@@ -50,11 +52,11 @@ The user is referred to the top-level README.md for more detailed instructions o
 NCEPLIBS-external and configure it (e.g., how to turn off building certain packages such as MPI etc).
 The default configuration assumes that all dependencies are built and installed: MPI, netCDF, ...
 
-cd /usr/local/ufs-release-v1/src
-git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+cd /usr/local/ufs-release-v1.1.0/src
+git clone -b ufs-v1.1.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
-cmake -DCMAKE_INSTALL_PREFIX=/usr/local/ufs-release-v1 .. 2>&1 | tee log.cmake
+cmake -DCMAKE_INSTALL_PREFIX=/usr/local/ufs-release-v1.1.0 .. 2>&1 | tee log.cmake
 make -j8 2>&1 | tee log.make
 # no make install needed
 
@@ -65,12 +67,12 @@ The user is referred to the top-level README.md of the NCEPLIBS GitHub repositor
 and build NCEPLIBS. The default configuration assumes that all dependencies were built
 by NCEPLIBS-external as described above.
 
-cd /usr/local/ufs-release-v1/src
-git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+cd /usr/local/ufs-release-v1.1.0/src
+git clone -b ufs-v1.1.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build
 cd build
-cmake -DCMAKE_INSTALL_PREFIX=/usr/local/ufs-release-v1 -DEXTERNAL_LIBS_DIR=/usr/local/ufs-release-v1 .. 2>&1 | tee log.cmake
+cmake -DCMAKE_INSTALL_PREFIX=/usr/local/ufs-release-v1.1.0 -DEXTERNAL_LIBS_DIR=/usr/local/ufs-release-v1.1.0 .. 2>&1 | tee log.cmake
 make -j8 2>&1 | tee log.make
 make install 2>&1 | tee log.install
 
@@ -93,7 +95,7 @@ export CC=gcc-9
 export FC=gfortran-9
 export CXX=g++-9
 ulimit -S -s unlimited
-. /usr/local/ufs-release-v1/bin/setenv_nceplibs.sh
+. /usr/local/ufs-release-v1.1.0/bin/setenv_nceplibs.sh
 export CMAKE_Platform=macosx.gnu
 ./build.sh 2>&1 | tee build.log
 

--- a/doc/README_orion_intel.txt
+++ b/doc/README_orion_intel.txt
@@ -23,23 +23,21 @@ export PNG_ROOT=/usr
 # Set environment variable WORK to a directory in your userspace, example for user dheinzel of group gmtb:
 #export WORK=/work/noaa/gmtb/dheinzel
 
-mkdir -p $WORK/NCEPLIBS-ufs-v1.0.0/intel-19.1.0.166/impi-2020.0.166/src
-cd $WORK/NCEPLIBS-ufs-v1.0.0/intel-19.1.0.166/impi-2020.0.166/src
+mkdir -p $WORK/NCEPLIBS-ufs-v1.1.0/intel-19.1.0.166/impi-2020.0.166/src
+cd $WORK/NCEPLIBS-ufs-v1.1.0/intel-19.1.0.166/impi-2020.0.166/src
 
-git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+git clone -b ufs-v1.1.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
 # If netCDF is not built, also don't build PNG, because netCDF uses the default (OS) zlib in the search path
-cmake -DBUILD_PNG=OFF -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=$WORK/NCEPLIBS-ufs-v1.0.0/intel-19.1.0.166/impi-2020.0.166 .. 2>&1 | tee log.cmake
+cmake -DBUILD_PNG=OFF -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=$WORK/NCEPLIBS-ufs-v1.1.0/intel-19.1.0.166/impi-2020.0.166 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
-# Fix orion bug that prevents using dynamically linked ESMF libraries: simply delete them
-rm $WORK/NCEPLIBS-ufs-v1.0.0/intel-19.1.0.166/impi-2020.0.166/lib64/libesmf*.so
 
-cd $WORK/NCEPLIBS-ufs-v1.0.0/intel-19.1.0.166/impi-2020.0.166/src
-git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+cd $WORK/NCEPLIBS-ufs-v1.1.0/intel-19.1.0.166/impi-2020.0.166/src
+git clone -b ufs-v1.1.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build && cd build
-cmake -DEXTERNAL_LIBS_DIR=$WORK/NCEPLIBS-ufs-v1.0.0/intel-19.1.0.166/impi-2020.0.166 -DCMAKE_INSTALL_PREFIX=$WORK/NCEPLIBS-ufs-v1.0.0/intel-19.1.0.166/impi-2020.0.166 .. 2>&1 | tee log.cmake
+cmake -DEXTERNAL_LIBS_DIR=$WORK/NCEPLIBS-ufs-v1.1.0/intel-19.1.0.166/impi-2020.0.166 -DCMAKE_INSTALL_PREFIX=$WORK/NCEPLIBS-ufs-v1.1.0/intel-19.1.0.166/impi-2020.0.166 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
 make install 2>&1 | tee log.install
 
@@ -71,7 +69,7 @@ export CMAKE_C_COMPILER=mpiicc
 export CMAKE_CXX_COMPILER=mpiicpc
 export CMAKE_Fortran_COMPILER=mpiifort
 
-. $WORK/NCEPLIBS-ufs-v1.0.0/intel-19.1.0.166/impi-2020.0.166/bin/setenv_nceplibs.sh
+. $WORK/NCEPLIBS-ufs-v1.1.0/intel-19.1.0.166/impi-2020.0.166/bin/setenv_nceplibs.sh
 export CMAKE_Platform=orion.intel
 cp cmake/configure_hera.intel.cmake cmake/configure_orion.intel.cmake
 ./build.sh 2>&1 | tee build.log

--- a/doc/README_redhat_gnu.txt
+++ b/doc/README_redhat_gnu.txt
@@ -100,7 +100,7 @@ the code are provided here: https://github.com/ufs-community/ufs-weather-model/w
 After checking out the code and changing to the top-level directory of ufs-weather-model,
 the following commands should suffice to build the model.
 
-
+scl enable gcc-toolset-9 bash
 export CC=gcc
 export CXX=g++
 export FC=gfortran

--- a/doc/README_stampede_intel.txt
+++ b/doc/README_stampede_intel.txt
@@ -26,22 +26,23 @@ export CXX=icpc
 export NETCDF=${TACC_NETCDF_DIR}
 export HDF5_ROOT=/opt/apps/intel18/hdf5/1.10.4/x86_64
 
-mkdir -p $WORK/NCEPLIBS-ufs-v1.0.0/src
-# for this particular user, this corresponds to /work/06146/tg854455/stampede2/NCEPLIBS-ufs-v1.0.0/src
+mkdir -p $WORK/NCEPLIBS-ufs-v1.1.0/src
+# $WORK is set automatically by the system; for the user writing these instructions,
+# it corresponds to /work/06146/tg854455/stampede2/NCEPLIBS-ufs-v1.1.0/src
 
-cd $WORK/NCEPLIBS-ufs-v1.0.0/src
-git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+cd $WORK/NCEPLIBS-ufs-v1.1.0/src
+git clone -b ufs-v1.1.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
 # If netCDF is not built, also don't build PNG, because netCDF uses the default (OS) zlib in the search path
-cmake -DBUILD_MPI=OFF -DBUILD_PNG=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=$WORK/NCEPLIBS-ufs-v1.0.0 .. 2>&1 | tee log.cmake
+cmake -DBUILD_MPI=OFF -DBUILD_PNG=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=$WORK/NCEPLIBS-ufs-v1.1.0 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
 
-cd $WORK/NCEPLIBS-ufs-v1.0.0/src
-git clone -b ufs-v1.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+cd $WORK/NCEPLIBS-ufs-v1.1.0/src
+git clone -b ufs-v1.1.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build && cd build
-cmake -DEXTERNAL_LIBS_DIR=$WORK/NCEPLIBS-ufs-v1.0.0 -DCMAKE_INSTALL_PREFIX=$WORK/NCEPLIBS-ufs-v1.0.0 .. 2>&1 | tee log.cmake
+cmake -DEXTERNAL_LIBS_DIR=$WORK/NCEPLIBS-ufs-v1.1.0 -DCMAKE_INSTALL_PREFIX=$WORK/NCEPLIBS-ufs-v1.1.0 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
 make install 2>&1 | tee log.install
 
@@ -80,6 +81,6 @@ export FC=ifort
 export CXX=icpc
 export NETCDF=${TACC_NETCDF_DIR}
 
-. $WORK/NCEPLIBS-ufs-v1.0.0/bin/setenv_nceplibs.sh
+. $WORK/NCEPLIBS-ufs-v1.1.0/bin/setenv_nceplibs.sh
 export CMAKE_Platform=stampede.intel
 ./build.sh 2>&1 | tee build.log


### PR DESCRIPTION
As the title says. Documentation changes only. After merging this PR, I will
- create branch release/public-v1
- strip out doc/README_*.txt for unsupported platforms for release/public-v1
- recreate tag ufs-v1.1.0 from release/public-v1
- create an issue to update the documentation in "develop" so that it works with the NCEPLIBS "develop" branch
