### PR TITLE
develop: doc/README_*.txt update part 2

### DIFF
--- a/doc/README_macos_clanggfortran.txt
+++ b/doc/README_macos_clanggfortran.txt
@@ -20,10 +20,10 @@ open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10
 
 (2) Create directories
 sudo su
-mkdir /usr/local/ufs-release-v1.1.0
-chown YOUR_USERNAME:YOUR_GROUPNAME /usr/local/ufs-release-v1.1.0
+mkdir /usr/local/ufs-develop
+chown YOUR_USERNAME:YOUR_GROUPNAME /usr/local/ufs-develop
 exit
-cd /usr/local/ufs-release-v1.1.0
+cd /usr/local/ufs-develop
 mkdir src
 
 (3) Install gcc-10.2.0/gfortran-10.2.0
@@ -63,29 +63,32 @@ The user is referred to the top-level README.md for more detailed instructions o
 NCEPLIBS-external and configure it (e.g., how to turn off building certain packages such as MPI etc).
 The default configuration assumes that all dependencies are built and installed: MPI, netCDF, ...
 
-cd /usr/local/ufs-release-v1.1.0/src
+cd /usr/local/ufs-develop/src
 git clone -b develop --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
-cmake -DCMAKE_INSTALL_PREFIX=/usr/local/ufs-release-v1.1.0 .. 2>&1 | tee log.cmake
+cmake -DCMAKE_INSTALL_PREFIX=/usr/local/ufs-develop .. 2>&1 | tee log.cmake
 make -j8 2>&1 | tee log.make
 # no make install needed
 
-3. Install NCEPLIBS
+
+3. Install NCEPLIBS - CURRENTLY BROKEN, STOP HERE. NEED TO ADD FORTRAN COMPILER FLAGS FOR GFORTRAN-10 SIMILAR TO WHAT WAS DONE FOR THE RELEASE/PUBLIC-V1 BRANCH; SEE ISSUE https://github.com/NOAA-EMC/NCEPLIBS/issues/106
+
+### FILE NEEDS UPDATE FROM HERE ON ###
 
 The user is referred to the top-level README.md of the NCEPLIBS GitHub repository
 (https://github.com/NOAA-EMC/NCEPLIBS/) for more detailed instructions on how to configure
 and build NCEPLIBS. The default configuration assumes that all dependencies were built
 by NCEPLIBS-external as described above.
 
-cd /usr/local/ufs-release-v1.1.0/src
+cd /usr/local/ufs-develop/src
 git clone -b develop --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build
 cd build
-cmake -DCMAKE_INSTALL_PREFIX=/usr/local/ufs-release-v1.1.0 -DEXTERNAL_LIBS_DIR=/usr/local/ufs-release-v1.1.0 .. 2>&1 | tee log.cmake
+cmake -DCMAKE_INSTALL_PREFIX=/usr/local/ufs-develop -DCMAKE_PREFIX_PATH=/usr/local/ufs-develop .. 2>&1 | tee log.cmake
 make -j8 2>&1 | tee log.make
-make install 2>&1 | tee log.install
+# no make install needed
 
 
 - END OF THE SETUP INSTRUCTIONS -
@@ -108,7 +111,7 @@ export CXX=clang++-9
 export PATH="/usr/local/opt/llvm/bin:$PATH"
 export LD_LIBRARY_PATH="/usr/local/opt/llvm/lib:$LD_LIBRARY_PATH"
 ulimit -S -s unlimited
-. /usr/local/ufs-release-v1.1.0/bin/setenv_nceplibs.sh
+. /usr/local/ufs-develop/bin/setenv_nceplibs.sh
 export CMAKE_Platform=macosx.gnu
 ./build.sh 2>&1 | tee build.log
 

--- a/doc/README_macos_gccgfortran.txt
+++ b/doc/README_macos_gccgfortran.txt
@@ -20,10 +20,10 @@ open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10
 
 (2) Create directories
 sudo su
-mkdir /usr/local/ufs-release-v1.1.0
-chown YOUR_USERNAME:YOUR_GROUPNAME /usr/local/ufs-release-v1.1.0
+mkdir /usr/local/ufs-develop
+chown YOUR_USERNAME:YOUR_GROUPNAME /usr/local/ufs-develop
 exit
-cd /usr/local/ufs-release-v1.1.0
+cd /usr/local/ufs-develop
 mkdir src
 
 (3) Install gcc-10.2.0/gfortran-10.2.0
@@ -56,29 +56,32 @@ The user is referred to the top-level README.md for more detailed instructions o
 NCEPLIBS-external and configure it (e.g., how to turn off building certain packages such as MPI etc).
 The default configuration assumes that all dependencies are built and installed: MPI, netCDF, ...
 
-cd /usr/local/ufs-release-v1.1.0/src
+cd /usr/local/ufs-develop/src
 git clone -b develop --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
-cmake -DCMAKE_INSTALL_PREFIX=/usr/local/ufs-release-v1.1.0 .. 2>&1 | tee log.cmake
+cmake -DCMAKE_INSTALL_PREFIX=/usr/local/ufs-develop .. 2>&1 | tee log.cmake
 make -j8 2>&1 | tee log.make
 # no make install needed
 
-3. Install NCEPLIBS
+
+3. Install NCEPLIBS - CURRENTLY BROKEN, STOP HERE. NEED TO ADD FORTRAN COMPILER FLAGS FOR GFORTRAN-10 SIMILAR TO WHAT WAS DONE FOR THE RELEASE/PUBLIC-V1 BRANCH; SEE ISSUE https://github.com/NOAA-EMC/NCEPLIBS/issues/106
+
+### FILE NEEDS UPDATE FROM HERE ON ###
 
 The user is referred to the top-level README.md of the NCEPLIBS GitHub repository
 (https://github.com/NOAA-EMC/NCEPLIBS/) for more detailed instructions on how to configure
 and build NCEPLIBS. The default configuration assumes that all dependencies were built
 by NCEPLIBS-external as described above.
 
-cd /usr/local/ufs-release-v1.1.0/src
+cd /usr/local/ufs-develop/src
 git clone -b develop --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build
 cd build
-cmake -DCMAKE_INSTALL_PREFIX=/usr/local/ufs-release-v1.1.0 -DEXTERNAL_LIBS_DIR=/usr/local/ufs-release-v1.1.0 .. 2>&1 | tee log.cmake
+cmake -DCMAKE_INSTALL_PREFIX=/usr/local/ufs-develop -DCMAKE_PREFIX_PATH=/usr/local/ufs-develop .. 2>&1 | tee log.cmake
 make -j8 2>&1 | tee log.make
-make install 2>&1 | tee log.install
+# no make install needed
 
 
 - END OF THE SETUP INSTRUCTIONS -
@@ -99,7 +102,7 @@ export CC=gcc-9
 export FC=gfortran-9
 export CXX=g++-9
 ulimit -S -s unlimited
-. /usr/local/ufs-release-v1.1.0/bin/setenv_nceplibs.sh
+. /usr/local/ufs-develop/bin/setenv_nceplibs.sh
 export CMAKE_Platform=macosx.gnu
 ./build.sh 2>&1 | tee build.log
 

--- a/doc/README_ubuntu_gnu.txt
+++ b/doc/README_ubuntu_gnu.txt
@@ -2,14 +2,14 @@
 # TODO: NEEDS UPDATE TO WORK WITH DEVELOP BRANCHES OF NCEPLIBS-EXTERNAL AND NCEPLIBS     #
 ##########################################################################################
 
-### Ubuntu Linux 18.04 LTS using gcc-8.3.0 and gfortran-8.3.0
+### Ubuntu Linux 20.04 LTS using gcc-8.3.0 and gfortran-8.3.0
 
 The following instructions were tested on a Ubuntu 18.04 Amazon EC2 compute node, which comes with
 essentially no packages installed. Many of the packages that are installed with apt in the
 following may already be installed on your system. Note that the apt Open MPI library did not
 work correctly in our tests, instead the NCEPLIBS-external MPICH version is used.
 
-AMI: ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20200810 (ami-0bcc094591f354be2)
+AMI: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200729 (ami-0758470213bdd23b1)
 
 Instance: t2.xlarge instance with 4 cores and 16GB of memory was used, 100GB EBS
 
@@ -18,36 +18,38 @@ Instance: t2.xlarge instance with 4 cores and 16GB of memory was used, 100GB EBS
 sudo su
 # Optional: this is usually a good idea, but should be used with care (it may destroy your existing setup)
 apt update
-# Install wget-1.19.4
+# Install wget-1.20.3
 apt install -y wget
-# Install git-2.17.1
+# Install git-2.25.1
 apt install -y git
-# Install make-4.1.9
+# Install make-4.2.1
 apt install -y make
 # Install libssl-dev-1.1.1
 apt install -y libssl-dev
 # Install patch-2.7.6
 apt install -y patch
-# Configure Python 3.6 as default
-update-alternatives --install /usr/bin/python python /usr/bin/python3.6 1
-# Install libxml2-utils-2.9.4 (for xmllint)
+# Configure Python 3.8 as default
+update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1
+# Install libxml2-utils-2.9.10 (for xmllint)
 apt install -y libxml2-utils
 # Install pkg-config-0.29.1
 apt install -y pkg-config
 # Install m4-1.4.18
 apt install m4
-# Install gcc-8.3.0, g++-8.3.0 and gfortran-8.3.0
-apt install -y gfortran-8 g++-8
+# Install gcc-9.3.0, g++-9.3.0 and gfortran-9.3.0
+apt install -y gfortran-9 g++-9
+# Install cmake-3.16.3
+apt install -y cmake
 
-mkdir /usr/local/ufs-release-v1.1.0
-chown -R ubuntu:ubuntu /usr/local/ufs-release-v1.1.0
+mkdir /usr/local/ufs-develop
+chown -R ubuntu:ubuntu /usr/local/ufs-develop
 exit
 
-export CC=gcc-8
-export CXX=g++-8
-export FC=gfortran-8
+export CC=gcc-9
+export CXX=g++-9
+export FC=gfortran-9
 
-cd /usr/local/ufs-release-v1.1.0
+cd /usr/local/ufs-develop
 mkdir src
 
 2.Install missing external libraries from NCEPLIBS-external
@@ -56,18 +58,14 @@ The user is referred to the top-level README.md for more detailed instructions o
 NCEPLIBS-external and configure it (e.g., how to turn off building certain packages such as MPI etc).
 The default configuration assumes that all dependencies are built and installed: MPI, netCDF, ...
 
-cd /usr/local/ufs-release-v1.1.0/src
+cd /usr/local/ufs-develop/src
 git clone -b develop --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
-# Install cmake 3.16.3 (default OS version is too old)
-cd cmake-src
-./bootstrap --prefix=/usr/local/ufs-release-v1.1.0
-make 2>&1 | tee log.make
-make install 2>&1 | tee log.install
-cd ..
 mkdir build && cd build
-/usr/local/ufs-release-v1.1.0/bin/cmake -DCMAKE_INSTALL_PREFIX=/usr/local/ufs-release-v1.1.0 .. 2>&1 | tee log.cmake
+cmake -DCMAKE_INSTALL_PREFIX=/usr/local/ufs-develop .. 2>&1 | tee log.cmake
 make -j8 2>&1 | tee log.make
+# no make install needed
+
 
 3. Install NCEPLIBS
 
@@ -76,14 +74,14 @@ The user is referred to the top-level README.md of the NCEPLIBS GitHub repositor
 and build NCEPLIBS. The default configuration assumes that all dependencies were built
 by NCEPLIBS-external as described above.
 
-cd /usr/local/ufs-release-v1.1.0/src
+cd /usr/local/ufs-develop/src
 git clone -b develop --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build
 cd build
-/usr/local/ufs-release-v1.1.0/bin/cmake -DCMAKE_INSTALL_PREFIX=/usr/local/ufs-release-v1.1.0 -DEXTERNAL_LIBS_DIR=/usr/local/ufs-release-v1.1.0 .. 2>&1 | tee log.cmake
+cmake -DCMAKE_INSTALL_PREFIX=/usr/local/ufs-develop -DCMAKE_PREFIX_PATH=/usr/local/ufs-develop .. 2>&1 | tee log.cmake
 make -j8 2>&1 | tee log.make
-make install 2>&1 | tee log.install
+# no make install needed
 
 
 - END OF THE SETUP INSTRUCTIONS -
@@ -100,11 +98,15 @@ After checking out the code and changing to the top-level directory of ufs-weath
 the following commands should suffice to build the model.
 
 
-export CC=gcc-8
-export CXX=g++-8
-export FC=gfortran-8
+export CC=gcc-9
+export CXX=g++-9
+export FC=gfortran-9
 ulimit -s unlimited
-. /usr/local/ufs-release-v1.1.0/bin/setenv_nceplibs.sh
+export PATH=/usr/local/ufs-develop/bin:$PATH
+export LD_LIBRARY_PATH=/usr/local/ufs-develop/lib:$PATH
+export NETCDF=/usr/local/ufs-develop
+export ESMFMKFILE=/usr/local/ufs-develop/lib/esmf.mk
+# DH note: for some reason, this suffices and the system finds all the NCEP libraries;
+# possibly the LD_LIBRARY_PATH makes cmake search for cmake config files in the right place
 export CMAKE_Platform=linux.gnu
 ./build.sh 2>&1 | tee build.log
-


### PR DESCRIPTION
Second round of addressing parts of issue #62: Update README_*.txt for macos_clanggfortran, macos_gccgfortran, redhat_gnu, ubuntu_gnu.

Documentation change only, will merge immediately.
