### PR TITLE
release/public-v1: update README for hera and jet

### DIFF
--- a/doc/README_hera_intel.txt
+++ b/doc/README_hera_intel.txt
@@ -3,22 +3,15 @@ Setup instructions for NOAA RDHPC Hera using Intel-18.0.5.274
 module purge
 module load intel/18.0.5.274
 module load impi/2018.0.4
-module load netcdf/4.7.0
 module load cmake/3.16.1
 module li
 
 > Currently Loaded Modules:
->  1) intel/18.0.5.274   2) impi/2018.0.4   3) netcdf/4.7.0   4) cmake/3.16.1
-
-# Note: HDF5 is in: /apps/hdf5/1.10.5/intel/18.0.5.274
-# Note: ZLIB and PNG are in: /usr/include, /usr/lib64/
+>  1) intel/18.0.5.274   2) impi/2018.0.4   3) cmake/3.16.1
 
 export CC=icc
 export CXX=icpc
 export FC=ifort
-
-export HDF5_ROOT=/apps/hdf5/1.10.5/intel/18.0.5.274
-export PNG_ROOT=/usr
 
 mkdir -p /scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.1.0/intel-18.0.5.274/impi-2018.0.4/src
 cd /scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.1.0/intel-18.0.5.274/impi-2018.0.4/src
@@ -26,8 +19,7 @@ cd /scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.1.0/intel-18.0.5.274/impi-2018.0.
 git clone -b ufs-v1.1.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
-# If netCDF is not built, also don't build PNG, because netCDF uses the default (OS) zlib in the search path
-cmake -DBUILD_PNG=OFF -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=/scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.1.0/intel-18.0.5.274/impi-2018.0.4 .. 2>&1 | tee log.cmake
+cmake -DBUILD_MPI=OFF -DCMAKE_INSTALL_PREFIX=/scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.1.0/intel-18.0.5.274/impi-2018.0.4 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
 
 cd /scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.1.0/intel-18.0.5.274/impi-2018.0.4/src
@@ -36,7 +28,7 @@ cd NCEPLIBS
 mkdir build && cd build
 cmake -DEXTERNAL_LIBS_DIR=/scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.1.0/intel-18.0.5.274/impi-2018.0.4 -DCMAKE_INSTALL_PREFIX=/scratch1/BMC/gmtb/software/NCEPLIBS-ufs-v1.1.0/intel-18.0.5.274/impi-2018.0.4 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
-make install
+make install 2>&1 | tee log.install
 
 
 - END OF THE SETUP INSTRUCTIONS -
@@ -56,7 +48,6 @@ the following commands should suffice to build the model.
 module purge
 module load intel/18.0.5.274
 module load impi/2018.0.4
-module load netcdf/4.7.0
 module load cmake/3.16.1
 
 export CC=icc
@@ -64,7 +55,7 @@ export CXX=icpc
 export FC=ifort
 
 module use -a /scratch1/BMC/gmtb/software/modulefiles/intel-18.0.5.274/impi-2018.0.4
-module load  NCEPlibs/1.1.0
+module load NCEPlibs/1.1.0
 
 export CMAKE_Platform=hera.intel
 ./build.sh 2>&1 | tee build.log

--- a/doc/README_jet_intel.txt
+++ b/doc/README_jet_intel.txt
@@ -3,22 +3,15 @@ Setup instructions for NOAA RDHPC Jet using Intel-18.0.5.274
 module purge
 module load intel/18.0.5.274
 module load impi/2018.4.274
-module load netcdf/4.7.0
 module load cmake/3.16.1
 module li
 
 > Currently Loaded Modules:
->  1) intel/18.0.5.274   2) impi/2018.4.274   3) netcdf/4.7.0   4) cmake/3.16.1
+>  1) intel/18.0.5.274   2) impi/2018.4.274   3) cmake/3.16.1
 
 export CC=icc
 export FC=ifort
 export CXX=icpc
-
-# HDF5 is in: /apps/hdf5/1.10.5/intel/18.0.5.274
-# ZLIB and PNG are in: /usr/include, /usr/lib64
-
-export HDF5_ROOT=/apps/hdf5/1.10.5/intel/18.0.5.274
-export PNG_ROOT=/usr
 
 mkdir -p /lfs4/HFIP/hfv3gfs/software/NCEPlibs-ufs-v1.1.0/intel-18.0.5.274/impi-2018.4.274/src
 cd /lfs4/HFIP/hfv3gfs/software/NCEPlibs-ufs-v1.1.0/intel-18.0.5.274/impi-2018.4.274/src
@@ -26,8 +19,7 @@ cd /lfs4/HFIP/hfv3gfs/software/NCEPlibs-ufs-v1.1.0/intel-18.0.5.274/impi-2018.4.
 git clone -b ufs-v1.1.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
-# If netCDF is not built, also don't build PNG, because netCDF uses the default (OS) zlib in the search path
-cmake -DBUILD_PNG=OFF -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=/lfs4/HFIP/hfv3gfs/software/NCEPlibs-ufs-v1.1.0/intel-18.0.5.274/impi-2018.4.274 .. 2>&1 | tee log.cmake
+cmake -DBUILD_MPI=OFF -DCMAKE_INSTALL_PREFIX=/lfs4/HFIP/hfv3gfs/software/NCEPlibs-ufs-v1.1.0/intel-18.0.5.274/impi-2018.4.274 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
 
 cd /lfs4/HFIP/hfv3gfs/software/NCEPlibs-ufs-v1.1.0/intel-18.0.5.274/impi-2018.4.274/src
@@ -36,7 +28,7 @@ cd NCEPLIBS
 mkdir build && cd build
 cmake -DEXTERNAL_LIBS_DIR=/lfs4/HFIP/hfv3gfs/software/NCEPlibs-ufs-v1.1.0/intel-18.0.5.274/impi-2018.4.274 -DCMAKE_INSTALL_PREFIX=/lfs4/HFIP/hfv3gfs/software/NCEPlibs-ufs-v1.1.0/intel-18.0.5.274/impi-2018.4.274 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
-make install
+make install 2>&1 | tee log.install
 
 
 - END OF THE SETUP INSTRUCTIONS -
@@ -56,7 +48,6 @@ the following commands should suffice to build the model.
 module purge
 module load intel/18.0.5.274
 module load impi/2018.4.274
-module load netcdf/4.7.0
 module load cmake/3.16.1
 
 export CC=icc


### PR DESCRIPTION
This is a documentation update only with changes in `doc/README_{hera,jet}_intel.txt` to match the changes in https://github.com/ufs-community/ufs-weather-model/pull/192.

No testing required, will merge as soon as https://github.com/ufs-community/ufs-weather-model/pull/192 is merged.