### PR TITLE
release/public-v2: documentation update

### DIFF
--- a/doc/README_cheyenne_gnu.txt
+++ b/doc/README_cheyenne_gnu.txt
@@ -1,7 +1,3 @@
-####################################################################################################
-# TODO: NEEDS UPDATE TO WORK WITH RELEASE/PUBLIC-V2 BRANCHES OF NCEPLIBS-EXTERNAL AND NCEPLIBS     #
-####################################################################################################
-
 Setup instructions for CISL Cheyenne using GNU-9.1.0
 
 NOTE: set "export INSTALL_PREFIX=..." as required for your installation (twice in this file!)
@@ -20,26 +16,22 @@ module li
 export CC=mpicc
 export FC=mpif90
 export CXX=mpicxx
-export INSTALL_PREFIX=/glade/work/heinzell/fv3/ufs-srweather-app/NCEPLIBS-test-20200813-gnu
+export INSTALL_PREFIX=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v2.0.0/gnu-9.1.0/mpt-2.19
 
 mkdir -p ${INSTALL_PREFIX}/src
 cd ${INSTALL_PREFIX}/src
 
-git clone -b develop --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+git clone -b ufs-v2.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
-cmake -DBUILD_MPI=OFF -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} .. 2>&1 | tee log.cmake
+cmake -DBUILD_MPI=OFF -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} -DDEPLOY=ON .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j2 2>&1 | tee log.make
 
-export NETCDF=${INSTALL_PREFIX}
-export ESMFMKFILE=${INSTALL_PREFIX}/lib64/esmf.mk
-export WGRIB2_ROOT=${INSTALL_PREFIX}
-
 cd ${INSTALL_PREFIX}/src
-git clone -b develop --recursive https://github.com/NOAA-EMC/NCEPLIBS
+git clone -b ufs-v2.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build && cd build
-cmake -DDEPLOY=ON -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} .. 2>&1 | tee log.cmake
+cmake -DCMAKE_PREFIX_PATH=${INSTALL_PREFIX} -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} -DOPENMP=ON -DDEPLOY=ON .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j2 2>&1 | tee log.make
 make deploy 2>&1 | tee log.deploy
 
@@ -68,24 +60,27 @@ module load cmake/3.16.4
 export CC=mpicc
 export FC=mpif90
 export CXX=mpicxx
-export INSTALL_PREFIX=/glade/work/heinzell/fv3/ufs-srweather-app/NCEPLIBS-test-20200813-gnu
 
-export NETCDF=${INSTALL_PREFIX}
-export ESMFMKFILE=${INSTALL_PREFIX}/lib64/esmf.mk
-export WGRIB2_ROOT=${INSTALL_PREFIX}
+module use /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v2.0.0/gnu-9.1.0/mpt-2.19/modules
 
-module use -a ${INSTALL_PREFIX}/modules
-module load bacio/2.4.0
-module load nemsio/2.5.1
-module load sp/2.3.0
-module load w3emc/2.7.0
-module load w3nco/2.4.0
-module load nceppost/dceca26
-module load sigio/2.3.0
-module load g2/3.4.0
-module load g2tmpl/1.9.0
-module load ip/3.3.0
+module load libpng/1.6.35
+module load netcdf/4.7.4
+module load esmf/8.0.0
+
+module load bacio/2.4.1
 module load crtm/2.3.0
+module load g2/3.4.1
+module load g2tmpl/1.9.1
+module load ip/3.3.3
+module load nceppost/dceca26
+module load nemsio/2.5.2
+module load sp/2.3.3
+module load w3emc/2.7.3
+module load w3nco/2.4.1
+
+module load gfsio/1.4.1
+module load sfcio/1.4.1
+module load sigio/2.3.2
 
 export CMAKE_Platform=cheyenne.gnu
 ./build.sh 2>&1 | tee build.log

--- a/doc/README_cheyenne_intel.txt
+++ b/doc/README_cheyenne_intel.txt
@@ -1,7 +1,3 @@
-####################################################################################################
-# TODO: NEEDS UPDATE TO WORK WITH RELEASE/PUBLIC-V2 BRANCHES OF NCEPLIBS-EXTERNAL AND NCEPLIBS     #
-####################################################################################################
-
 Setup instructions for CISL Cheyenne using Intel-19.1.1
 
 NOTE: set "export INSTALL_PREFIX=..." as required for your installation
@@ -20,26 +16,22 @@ module li
 export CC=mpicc
 export FC=mpif90
 export CXX=mpicxx
-export INSTALL_PREFIX=/glade/work/heinzell/fv3/ufs-srweather-app/NCEPLIBS-test-20200813-intel
+export INSTALL_PREFIX=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v2.0.0/intel-19.1.1/mpt-2.19
 
 mkdir -p ${INSTALL_PREFIX}/src
 cd ${INSTALL_PREFIX}/src
 
-git clone -b develop --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+git clone -b ufs-v2.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
-cmake -DBUILD_MPI=OFF -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} .. 2>&1 | tee log.cmake
+cmake -DBUILD_MPI=OFF -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} -DDEPLOY=ON .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j2 2>&1 | tee log.make
 
-export NETCDF=${INSTALL_PREFIX}
-export ESMFMKFILE=${INSTALL_PREFIX}/lib64/esmf.mk
-export WGRIB2_ROOT=${INSTALL_PREFIX}
-
-cd ${INSTALL_PREFIX}/src/
-git clone -b develop --recursive https://github.com/NOAA-EMC/NCEPLIBS
+cd ${INSTALL_PREFIX}/src
+git clone -b ufs-v2.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build && cd build
-cmake -DDEPLOY=ON -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} .. 2>&1 | tee log.cmake
+cmake -DCMAKE_PREFIX_PATH=${INSTALL_PREFIX} -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} -DOPENMP=ON -DDEPLOY=ON .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j2 2>&1 | tee log.make
 make deploy 2>&1 | tee log.deploy
 
@@ -48,7 +40,7 @@ make deploy 2>&1 | tee log.deploy
 
 
 The following instructions are for building the ufs-weather-model (standalone;
-not the ufs-mrweather app - for the latter, the model is built by the workflow)
+not the UFS applications - for the latter, the model is built by the workflow)
 with those libraries installed.
 
 This is separate from NCEPLIBS-external and NCEPLIBS, and details on how to get
@@ -68,24 +60,27 @@ module load cmake/3.16.4
 export CC=mpicc
 export FC=mpif90
 export CXX=mpicxx
-export INSTALL_PREFIX=/glade/work/heinzell/fv3/ufs-srweather-app/NCEPLIBS-test-20200813-intel
 
-export NETCDF=${INSTALL_PREFIX}
-export ESMFMKFILE=${INSTALL_PREFIX}/lib64/esmf.mk
-export WGRIB2_ROOT=${INSTALL_PREFIX}
+module use /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v2.0.0/intel-19.1.1/mpt-2.19/modules
 
-module use -a ${INSTALL_PREFIX}/modules
-module load bacio/2.4.0
-module load nemsio/2.5.1
-module load sp/2.3.0
-module load w3emc/2.7.0
-module load w3nco/2.4.0
-module load nceppost/dceca26
-module load sigio/2.3.0
-module load g2/3.4.0
-module load g2tmpl/1.9.0
-module load ip/3.3.0
+module load libpng/1.6.35
+module load netcdf/4.7.4
+module load esmf/8.0.0
+
+module load bacio/2.4.1
 module load crtm/2.3.0
+module load g2/3.4.1
+module load g2tmpl/1.9.1
+module load ip/3.3.3
+module load nceppost/dceca26
+module load nemsio/2.5.2
+module load sp/2.3.3
+module load w3emc/2.7.3
+module load w3nco/2.4.1
+
+module load gfsio/1.4.1
+module load sfcio/1.4.1
+module load sigio/2.3.2
 
 export CMAKE_Platform=cheyenne.intel
 ./build.sh 2>&1 | tee build.log

--- a/doc/README_docker_gnu.md
+++ b/doc/README_docker_gnu.md
@@ -1,0 +1,255 @@
+### WORK IN PROGRESS ###
+
+The four subdirectories each contain a docker container and the
+Dockerfile used to create it. The container has a Linux distribution,
+the NCEPLIBS, and a compiled ufs-weather-model.  The Dockerfile can be
+used to recreate the container. The Dockerfile has a sequence of
+installation commands on top of an initial Linux image. If you need to
+install in another environment, such as a physical Linux installation
+or cloud computing, you can manually run the commands on the target
+machine or convert the Dockerfile to another format.
+
+The four containers will work on any operating system with the Docker
+Engine installed. Their names are based on the Linux distribution
+found within. Due to the design of Docker, you can mix and match
+operating systems: run the centos7 container on XUbuntu 18 or the
+ubuntu20 container on Windows 10.
+
+- ubuntu20 -- Based on the `ubuntu:20.04` image from DockerHub
+- ubuntu18 -- Based on the `ubuntu:18.04` image from DockerHub
+- centos7 -- Based on the `centos:centos7` image from DockerHub
+- centos8 -- Based on the `centos:centos8` image from DockerHub
+
+
+
+### Get Docker
+
+Before you can follow any of these instructions, you need to install
+the Docker Engine. The method depends on your platform. To get the
+official Docker releases, go to their Release Channels. Otherwise,
+your operating system's package repository may have Docker. It's
+likely called "docker" or "docker.io"
+
+If you want the most recent version of Docker, full instructions for
+all platforms Docker supports are here:
+
+* https://docs.docker.com/engine/install/
+
+Relevant pages for Ubuntu and RedHat/CentOS:
+
+* UBUNTU: https://docs.docker.com/engine/install/ubuntu/
+* REDHAT/CENTOS: https://docs.docker.com/engine/install/centos/
+* Optional post-install steps: https://docs.docker.com/engine/install/linux-postinstall/
+
+
+### Security Risks
+
+Containerization technologies such as Docker are security risks unless
+they are used correctly. Before using Docker on a production
+environment, or any other situation where the security of your machine
+is critical, make sure you plan accordingly:
+
+https://docs.docker.com/engine/security/security/
+
+These containers were built and tested in a virtual machine, to fully
+isolate Docker from the host. If your machine has hardware
+virtualization support, that is an excellent option. Cloud computing
+providers also use virtualization. Running inside a cloud provider's
+container service is another option.
+
+
+
+Importing and Running
+---------------------
+
+These instructions tell you how to run the docker container on a
+typical Linux machine via the command line. The process is different
+for Windows and MacOS. We assume you already have Docker installed
+
+
+### STEP 1 (Plan A): Import the Compressed File
+
+With recent software, you should be able to import the `*.tar.xz` file
+directly to Docker:
+
+    docker import docker-container.tar.xz
+
+If it works, it'll print a long hexadecimal string; this is the hash
+of your docker image:
+
+    sha256:dc49f3340437448df52a27655ae8437961b39eaf2ceb7304a21591eeff6a5e48
+
+If that worked, great! Jump to step 4, but don't lose that hash;
+you'll need it soon.
+
+
+### STEP 2 (Plan B): Decompress Manually
+
+If Docker complains that it cannot understand the file format, you may
+need to decompress the file using `xz`. To install `xz`:
+
+    UBUNTU: sudo apt-get install xz-utils
+    REDHAT/CENTOS: sudo yum install xz
+
+Then decompress:
+
+    xz -dk docker-container.tar.xz
+
+There should now be a "docker-container.tar" file.
+
+
+### STEP 3 (Plan B): Import the Decompressed File
+
+Import the file you manually decompressed:
+
+    docker import docker-container.tar
+
+If it works, it'll print a long hexadecimal string; this is the hash
+of your docker image. 
+
+    sha256:dc49f3340437448df52a27655ae8437961b39eaf2ceb7304a21591eeff6a5e48
+
+Remember the hash; you'll need it in step 4.
+
+
+### STEP 4: Tag
+
+Docker tags let you rename the hashes to something easily
+remembered. In this example, let's call the image `ufs-srweather-v2`:
+
+    docker tag dc49f3340437448df52a27655ae8437961b39eaf2ceb7304a21591eeff6a5e48 ufs-srweather-v2
+
+
+### STEP 5: Get a login shell in the image
+
+The "docker run" command creates a container from your image and runs
+a command inside. We'll get a bash login shell:
+
+    docker run -it ufs-srweather-v2 bash --login
+
+You should now have a root login within your container.
+
+    cd /usr/local/ufs-develop/src/ufs-weather-model/
+    ls
+
+You should see the familiar contents of the ufs-weather-model checkout:
+
+    CMakeLists.txt  LICENSE.md  WW3        build.sh  fms_files.cmake  stochastic_physics
+    FMS             NEMS        build      cmake     modulefiles      tests
+    FV3             README.md   build.log  conf      parm             ufs_weather_model
+
+The bottom-right file is the executable.
+
+
+
+Rebuilding
+----------
+
+This section tells you how to recreate the docker container from the
+Dockerfile. 
+
+If you want to do this, we suggest you do NOT use the CentOS 7
+Dockerfile because it compiles GCC, which can take a long time even on
+large machines.
+
+
+
+### STEP 2: Download NCEPLIBS-external OR Edit Dockerfile
+
+It takes a long time to download the HDF5 repository within the
+NCEPLIBS-external. If you're going to tweak the Dockerfile many times,
+you'll want to download that software only once. That's the default
+behavior as seen in these lines of the Dockerfile:
+
+    COPY DATA/NCEPLIBS-external /usr/local/ufs-develop/src/NCEPLIBS-external
+    # It takes an eternity to clone the HDF5 repo, so I kept a local disk copy of this:
+    #RUN git clone -b develop --recursive https://github.com/NOAA-EMC/NCEPLIBS-external /usr/local/ufs-develop/src/NCEPLIBS-external
+    # If you prefer, comment out the COPY line and uncomment the "RUN git..." line
+
+#### Option 1: Download NCEPLIBS-external
+
+If you don't have the "git" command, you'll need to install it:
+
+    UBUNTU: apt-get install git
+    REDHAT/CENTOS: yum install git
+
+Then download the NCEPLIBS-external where the Dockerfile expects it:
+
+    mkdir DATA
+    git clone -b develop --recursive https://github.com/NOAA-EMC/NCEPLIBS-external DATA/NCEPLIBS-external
+
+#### Option 2: Have the Docker Container Download it For You
+
+As the comments say, if you only intend to build once, then comment
+out the COPY line and uncomment the RUN line in the Dockerfile.
+
+Change these two lines:
+
+    COPY DATA/NCEPLIBS-external /usr/local/ufs-develop/src/NCEPLIBS-external
+    #RUN git clone -b develop --recursive https://github.com/NOAA-EMC/NCEPLIBS-external /usr/local/ufs-develop/src/NCEPLIBS-external
+
+to this:
+
+    #COPY DATA/NCEPLIBS-external /usr/local/ufs-develop/src/NCEPLIBS-external
+    RUN git clone -b develop --recursive https://github.com/NOAA-EMC/NCEPLIBS-external /usr/local/ufs-develop/src/NCEPLIBS-external
+
+Now the COPY command is commented out, and the RUN command is uncommented.
+
+
+### STEP 3: Build
+
+Change your working directory (`cd`) to the directory with the `Dockerfile` and run:
+
+    docker build .
+
+You should see a long sequence of installation and build commands for
+several hours. On an especially slow machine, it may take a
+day. Eventually, if all goes according to plan, you should see a
+message like this, but with a different hash:
+
+    Successfully built a379fe2388c2
+
+Now tag the hash, giving it a nickname you'll remember:
+
+    docker tag a379fe2388c2 my-ufs-srweather-v2
+
+
+### STEP 4 (Optional) Export
+
+To get the tar file we distribute, do this:
+
+    docker export my-ufs-srweather-v2 > my-ufs-srweather-v2.tar
+
+### STEP 5 (Optional) Compress the Exported File
+
+We used `xz -9` to compress the files, which may take several hours on a slow machine.
+
+To get xz:
+
+    UBUNTU: sudo apt-get install xz-utils
+    REDHAT/CENTOS: sudo yum install xz
+
+To compress:
+
+    xz -9 --compress --stdout my-ufs-srweather-v2.tar > my-ufs-srweather-v2.tar.xz
+
+### STEP 6: Run
+
+The process is the same as running from our distributed docker container.
+The "docker run" command creates a container from your image and runs
+a command inside. We'll get a bash login shell:
+
+    docker run -it my-ufs-srweather-v2 bash --login
+
+You should now have a root login within your container.
+
+    cd /usr/local/ufs-develop/src/ufs-weather-model/
+    ls
+
+You should see the familiar contents of the ufs-weather-model checkout:
+
+    CMakeLists.txt  LICENSE.md  WW3        build.sh  fms_files.cmake  stochastic_physics
+    FMS             NEMS        build      cmake     modulefiles      tests
+    FV3             README.md   build.log  conf      parm             ufs_weather_model
+
+The bottom-right file is the executable.

--- a/doc/README_gaea_intel.txt
+++ b/doc/README_gaea_intel.txt
@@ -1,7 +1,3 @@
-####################################################################################################
-# TODO: NEEDS UPDATE TO WORK WITH RELEASE/PUBLIC-V2 BRANCHES OF NCEPLIBS-EXTERNAL AND NCEPLIBS     #
-####################################################################################################
-
 Setup instructions for NOAA RDHPC Gaea using Cray Intel-19.0.5.281
 
 module load intel/19.0.5.281
@@ -12,12 +8,12 @@ module load cmake/3.17.0
 module li
 
 > Currently Loaded Modulefiles:
->   1) modules/3.2.11.4                                 7) udreg/2.3.2-7.0.2.1_2.15__g8175d3d.ari          13) job/2.2.4-7.0.2.1_2.18__g36b56f4.ari            19) PrgEnv-intel/6.0.5                              25) darshan/3.2.1
->   2) eproxy/2.0.24-7.0.2.1_2.20__g8e04b33.ari         8) ugni/6.0.14.0-7.0.2.1_3.15__ge78e5b0.ari        14) dvs/2.12_2.2.164-7.0.2.1_3.8__g1afc88eb         20) craype-broadwell                                26) DefApps
->   3) intel/19.0.5.281                                 9) pmi/5.0.15                                      15) alps/6.6.59-7.0.2.1_3.7__g872a8d62.ari          21) cray-mpich/7.7.11                               27) hpcrpt/noaa-3
->   4) craype-network-aries                            10) dmapp/7.1.1-7.0.2.1_2.19__g38cf134.ari          16) rca/2.2.20-7.0.2.1_2.20__g8e3fb5b.ari           22) CmrsEnv                                         28) cmake/3.17.0
->   5) craype/2.6.3                                    11) gni-headers/5.0.12.0-7.0.2.1_2.4__g3b1768f.ari  17) atp/2.1.3                                       23) TimeZoneEDT
->   6) cray-libsci/19.06.1                             12) xpmem/2.2.20-7.0.2.1_2.15__g87eb960.ari         18) perftools-base/7.1.3                            24) globus-toolkit/6.0.17
+>  1) modules/3.2.11.4                                 7) udreg/2.3.2-7.0.2.1_2.15__g8175d3d.ari          13) job/2.2.4-7.0.2.1_2.18__g36b56f4.ari            19) PrgEnv-intel/6.0.5                              25) DefApps
+>  2) eproxy/2.0.24-7.0.2.1_2.20__g8e04b33.ari         8) ugni/6.0.14.0-7.0.2.1_3.15__ge78e5b0.ari        14) dvs/2.12_2.2.164-7.0.2.1_3.8__g1afc88eb         20) craype-broadwell                                26) hpcrpt/noaa-3
+>  3) intel/19.0.5.281                                 9) pmi/5.0.15                                      15) alps/6.6.59-7.0.2.1_3.7__g872a8d62.ari          21) CmrsEnv                                         27) cray-mpich/7.7.11
+>  4) craype-network-aries                            10) dmapp/7.1.1-7.0.2.1_2.19__g38cf134.ari          16) rca/2.2.20-7.0.2.1_2.20__g8e3fb5b.ari           22) TimeZoneEDT                                     28) cmake/3.17.0
+>  5) craype/2.6.3                                    11) gni-headers/5.0.12.0-7.0.2.1_2.4__g3b1768f.ari  17) atp/2.1.3                                       23) globus-toolkit/6.0.17
+>  6) cray-libsci/19.06.1                             12) xpmem/2.2.20-7.0.2.1_2.15__g87eb960.ari         18) perftools-base/7.1.3                            24) darshan/3.2.1
 
 # Need to use MPI wrappers in order to find pre-installed Cray MPICH
 export CC=cc
@@ -25,32 +21,47 @@ export FC=ftn
 export CXX=CC
 export MPI_ROOT=/opt/cray/pe/mpt/7.7.11/gni/mpich-intel/16.0
 
-mkdir -p /lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-develop/intel-19.0.5.281/cray-mpich-7.7.11/src
+export INSTALL_PREFIX=/lustre/f2/pdata/esrl/gsd/ufs/NCEPLIBS-ufs-v2.0.0/intel-18.0.6.288/cray-mpich-7.7.11
 
-cd /lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-develop/intel-19.0.5.281/cray-mpich-7.7.11/src
+mkdir -p ${INSTALL_PREFIX}/src
+cd ${INSTALL_PREFIX}/src
+
 # Note: remote access severely limited on gaea; need to do the git clone on a remote system and rsync to gaea
-git clone -b develop --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+git clone -b ufs-v2.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
-cmake -DBUILD_MPI=OFF -DCMAKE_INSTALL_PREFIX=/lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-develop/intel-19.0.5.281/cray-mpich-7.7.11 .. 2>&1 | tee log.cmake
+cmake -DBUILD_MPI=OFF -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} -DDEPLOY=ON .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
-# no make install necessary
 
-cd /lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-develop/intel-19.0.5.281/cray-mpich-7.7.11/src
-# Note: remote access severely limited on gaea; need to do the git clone on a remote system and rsync to gaea
-git clone -b develop --recursive https://github.com/NOAA-EMC/NCEPLIBS
+cd ${INSTALL_PREFIX}/src
+# Note: remote access severely limited on gaea; need to do the git clone on a remote system and rsync to gaea;
+# for NCEPLIBS, this requires a few more steps:
+# on a machine with internet access, do:
+git clone -b ufs-v2.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+cd NCEPLIBS
+mkdir tmp && cd tmp
+cmake -DDOWNLOAD_ONLY=ON .. 2>&1 | tee log.cmake
+make 2>&1 | tee log.make
+cd ..
+rm -fr tmp
+# then rsync the entire NCEPLIBS folder to gaea ${INSTALL_PREFIX}/src/NCEPLIBS/
+git clone -b ufs-v2.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build && cd build
-cmake -DEXTERNAL_LIBS_DIR=/lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-develop/intel-19.0.5.281/cray-mpich-7.7.11 -DCMAKE_INSTALL_PREFIX=/lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-develop/intel-19.0.5.281/cray-mpich-7.7.11 .. 2>&1 | tee log.cmake
+# Tell CMake to use the previously downloaded packages
+cmake -DCMAKE_PREFIX_PATH=${INSTALL_PREFIX} -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} -DDEPLOY=ON -DOPENMP=ON -DUSE_LOCAL=ON .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
-make install VERBOSE=1 2>&1 | tee log.install
+make deploy 2>&1 | tee log.deploy
+cd ..
+# Convert lua modulefiles into tcl modulefiles
+./lua2tcl.py ${INSTALL_PREFIX}/modules
 
 
 - END OF THE SETUP INSTRUCTIONS -
 
 
 The following instructions are for building the ufs-weather-model (standalone;
-not the ufs-mrweather app - for the latter, the model is built by the workflow)
+not the UFS applications - for the latter, the model is built by the workflow)
 with those libraries installed.
 
 This is separate from NCEPLIBS-external and NCEPLIBS, and details on how to get
@@ -59,20 +70,39 @@ the code are provided here: https://github.com/ufs-community/ufs-weather-model/w
 After checking out the code and changing to the top-level directory of ufs-weather-model,
 the following commands should suffice to build the model.
 
-
 module load intel/19.0.5.281
 module unload cray-mpich
 module load cray-mpich/7.7.11
 module unload cray-netcdf
 module load cmake/3.17.0
-module li
 
-module use -a /lustre/f2/pdata/esrl/gsd/ufs/modules/modulefiles/intel-19.0.5.281/cray-mpich-7.7.11
-module load NCEPlibs/1.1.0
+export CC=cc
+export FC=ftn
+export CXX=CC
 
-export CMAKE_Platform=gaea.intel
+module use /lustre/f2/pdata/esrl/gsd/ufs/NCEPLIBS-ufs-v2.0.0/intel-18.0.6.288/cray-mpich-7.7.11/modules
+
+module load libpng/1.6.35
+module load netcdf/4.7.4
+module load esmf/8.0.0
+
+module load bacio/2.4.1
+module load crtm/2.3.0
+module load g2/3.4.1
+module load g2tmpl/1.9.1
+module load ip/3.3.3
+module load nceppost/dceca26
+module load nemsio/2.5.2
+module load sp/2.3.3
+module load w3emc/2.7.3
+module load w3nco/2.4.1
+
+module load gfsio/1.4.1
+module load sfcio/1.4.1
+module load sigio/2.3.2
+
 export CMAKE_C_COMPILER=cc
 export CMAKE_CXX_COMPILER=CC
 export CMAKE_Fortran_COMPILER=ftn
-
+export CMAKE_Platform=gaea.intel
 ./build.sh 2>&1 | tee build.log

--- a/doc/README_gaea_intel.txt
+++ b/doc/README_gaea_intel.txt
@@ -21,7 +21,7 @@ export FC=ftn
 export CXX=CC
 export MPI_ROOT=/opt/cray/pe/mpt/7.7.11/gni/mpich-intel/16.0
 
-export INSTALL_PREFIX=/lustre/f2/pdata/esrl/gsd/ufs/NCEPLIBS-ufs-v2.0.0/intel-18.0.6.288/cray-mpich-7.7.11
+export INSTALL_PREFIX=/lustre/f2/pdata/esrl/gsd/ufs/NCEPLIBS-ufs-v2.0.0/intel-19.0.5.281/cray-mpich-7.7.11
 
 mkdir -p ${INSTALL_PREFIX}/src
 cd ${INSTALL_PREFIX}/src
@@ -80,7 +80,7 @@ export CC=cc
 export FC=ftn
 export CXX=CC
 
-module use /lustre/f2/pdata/esrl/gsd/ufs/NCEPLIBS-ufs-v2.0.0/intel-18.0.6.288/cray-mpich-7.7.11/modules
+module use /lustre/f2/pdata/esrl/gsd/ufs/NCEPLIBS-ufs-v2.0.0/intel-19.0.5.281/cray-mpich-7.7.11/modules
 
 module load libpng/1.6.35
 module load netcdf/4.7.4

--- a/doc/README_macos_clanggfortran.txt
+++ b/doc/README_macos_clanggfortran.txt
@@ -10,7 +10,7 @@ are required for the subsequent steps, as well as for building NCEPLIBS-external
 
 Note that 16GB of memory are required for running the UFS weather model at C96 resolution.
 
-1. Install homebrew, the LLVM/GNU compilers and other utilities
+1. Install homebrew, the LLVM/GNU compilers and other utilities:
 
 (1) Install homebrew
 /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
@@ -20,10 +20,12 @@ open /Library/Developer/CommandLineTools/Packages/macOS_SDK_headers_for_macOS_10
 
 (2) Create directories
 sudo su
-mkdir /usr/local/ufs-develop
-chown YOUR_USERNAME:YOUR_GROUPNAME /usr/local/ufs-develop
+export INSTALL_PREFIX=/usr/local/NCEPLIBS-ufs-v2.0.0
+mkdir ${INSTALL_PREFIX}
+chown YOUR_USERNAME:YOUR_GROUPNAME ${INSTALL_PREFIX}
 exit
-cd /usr/local/ufs-develop
+export INSTALL_PREFIX=/usr/local/NCEPLIBS-ufs-v2.0.0
+cd ${INSTALL_PREFIX}
 mkdir src
 
 (3) Install gcc-10.2.0/gfortran-10.2.0
@@ -63,39 +65,34 @@ The user is referred to the top-level README.md for more detailed instructions o
 NCEPLIBS-external and configure it (e.g., how to turn off building certain packages such as MPI etc).
 The default configuration assumes that all dependencies are built and installed: MPI, netCDF, ...
 
-cd /usr/local/ufs-develop/src
-git clone -b develop --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+cd ${INSTALL_PREFIX}/src
+git clone -b ufs-v2.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
-cmake -DCMAKE_INSTALL_PREFIX=/usr/local/ufs-develop .. 2>&1 | tee log.cmake
+cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} .. 2>&1 | tee log.cmake
 make -j8 2>&1 | tee log.make
-# no make install needed
 
 
-3. Install NCEPLIBS - CURRENTLY BROKEN, STOP HERE. NEED TO ADD FORTRAN COMPILER FLAGS FOR GFORTRAN-10 SIMILAR TO WHAT WAS DONE FOR THE RELEASE/PUBLIC-V1 BRANCH; SEE ISSUE https://github.com/NOAA-EMC/NCEPLIBS/issues/106
-
-### FILE NEEDS UPDATE FROM HERE ON ###
+3. Install NCEPLIBS
 
 The user is referred to the top-level README.md of the NCEPLIBS GitHub repository
 (https://github.com/NOAA-EMC/NCEPLIBS/) for more detailed instructions on how to configure
 and build NCEPLIBS. The default configuration assumes that all dependencies were built
 by NCEPLIBS-external as described above.
 
-cd /usr/local/ufs-develop/src
-git clone -b develop --recursive https://github.com/NOAA-EMC/NCEPLIBS
+cd ${INSTALL_PREFIX}/src
+git clone -b ufs-v2.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
-mkdir build
-cd build
-cmake -DCMAKE_INSTALL_PREFIX=/usr/local/ufs-develop -DCMAKE_PREFIX_PATH=/usr/local/ufs-develop .. 2>&1 | tee log.cmake
+mkdir build && cd build
+cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} -DCMAKE_PREFIX_PATH=${INSTALL_PREFIX} -DOPENMP=ON .. 2>&1 | tee log.cmake
 make -j8 2>&1 | tee log.make
-# no make install needed
 
 
 - END OF THE SETUP INSTRUCTIONS -
 
 
 The following instructions are for building the ufs-weather-model (standalone;
-not the ufs-mrweather app - for the latter, the model is built by the workflow)
+not the UFS applications - for the latter, the model is built by the workflow)
 with those libraries installed.
 
 This is separate from NCEPLIBS-external and NCEPLIBS, and details on how to get
@@ -104,6 +101,7 @@ the code are provided here: https://github.com/ufs-community/ufs-weather-model/w
 After checking out the code and changing to the top-level directory of ufs-weather-model,
 the following commands should suffice to build the model.
 
+export INSTALL_PREFIX=/usr/local/NCEPLIBS-ufs-v2.0.0
 
 export CC=clang-9
 export FC=gfortran-9
@@ -112,11 +110,12 @@ export PATH="/usr/local/opt/llvm/bin:$PATH"
 export LD_LIBRARY_PATH="/usr/local/opt/llvm/lib:$LD_LIBRARY_PATH"
 ulimit -S -s unlimited
 
-### DH* TODO - HOW ??? . ${INSTALL_PREFIX}/bin/setenv_nceplibs.sh
+export NETCDF=${INSTALL_PREFIX}
+export ESMFMKFILE=${INSTALL_PREFIX}/lib/esmf.mk
+export CMAKE_PREFIX_PATH=${INSTALL_PREFIX}
 
 export CMAKE_Platform=macosx.gnu
 ./build.sh 2>&1 | tee build.log
 
-Note. OpenMP support is currently broken with the clang compiler. The UFS models should detect that
-the clang compiler is used and turn off threading when building the model.
-
+Note. OpenMP support is currently broken with the clang compiler. The UFS models should
+detect that the clang compiler is used and turn off threading when building the model.

--- a/doc/README_macos_clanggfortran.txt
+++ b/doc/README_macos_clanggfortran.txt
@@ -1,7 +1,3 @@
-####################################################################################################
-# TODO: NEEDS UPDATE TO WORK WITH RELEASE/PUBLIC-V2 BRANCHES OF NCEPLIBS-EXTERNAL AND NCEPLIBS     #
-####################################################################################################
-
 Setup instructions for macOS Mojave or Catalina using clang-10.0.0 + gfortran-10.2.0
 
 The following instructions were tested on a clean macOS systems (Mojave 10.14.6 and Catalina 10.15.6).

--- a/doc/README_macos_gccgfortran.txt
+++ b/doc/README_macos_gccgfortran.txt
@@ -59,7 +59,7 @@ NCEPLIBS-external and configure it (e.g., how to turn off building certain packa
 The default configuration assumes that all dependencies are built and installed: MPI, netCDF, ...
 
 cd ${INSTALL_PREFIX}/src
-git clone -b develop --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+git clone -b ufs-v2.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} .. 2>&1 | tee log.cmake
@@ -74,7 +74,7 @@ and build NCEPLIBS. The default configuration assumes that all dependencies were
 by NCEPLIBS-external as described above.
 
 cd ${INSTALL_PREFIX}/src
-git clone -b develop --recursive https://github.com/NOAA-EMC/NCEPLIBS
+git clone -b ufs-v2.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} -DCMAKE_PREFIX_PATH=${INSTALL_PREFIX} -DOPENMP=ON .. 2>&1 | tee log.cmake
@@ -85,7 +85,7 @@ make -j8 2>&1 | tee log.make
 
 
 The following instructions are for building the ufs-weather-model (standalone;
-not the ufs-mrweather app - for the latter, the model is built by the workflow)
+not the UFS applications - for the latter, the model is built by the workflow)
 with those libraries installed.
 
 This is separate from NCEPLIBS-external and NCEPLIBS, and details on how to get
@@ -99,10 +99,11 @@ export INSTALL_PREFIX=/usr/local/NCEPLIBS-ufs-v2.0.0
 export CC=gcc-10
 export FC=gfortran-10
 export CXX=g++-10
-
 ulimit -S -s unlimited
 
-### DH* TODO - HOW ??? . ${INSTALL_PREFIX}/bin/setenv_nceplibs.sh
+export NETCDF=${INSTALL_PREFIX}
+export ESMFMKFILE=${INSTALL_PREFIX}/lib/esmf.mk
+export CMAKE_PREFIX_PATH=${INSTALL_PREFIX}
 
 export CMAKE_Platform=macosx.gnu
 ./build.sh 2>&1 | tee build.log

--- a/doc/README_macos_gccgfortran.txt
+++ b/doc/README_macos_gccgfortran.txt
@@ -1,7 +1,3 @@
-####################################################################################################
-# TODO: NEEDS UPDATE TO WORK WITH RELEASE/PUBLIC-V2 BRANCHES OF NCEPLIBS-EXTERNAL AND NCEPLIBS     #
-####################################################################################################
-
 Setup instructions for macOS Mojave or Catalina using gcc-10.2.0 + gfortran-10.2.0
 
 The following instructions were tested on a clean macOS systems (Mojave 1.14.6 and Catalina 10.15.2).

--- a/doc/README_odin_intel.txt
+++ b/doc/README_odin_intel.txt
@@ -1,0 +1,117 @@
+Setup instructions for NSSL RDHPC Odin using Intel-19.0.5.281
+
+module purge
+module load slurm/19.05.3-2
+module load craype/2.6.2
+module load cray-mpich/7.7.10
+module load craype-network-aries
+module load cray-libsci/19.06.1
+module load pmi/5.0.14
+module load PrgEnv-intel/6.0.5
+module swap intel/19.0.5.281
+module load craype-ivybridge
+module load cray-netcdf-hdf5parallel/4.6.3.2
+module load cray-parallel-netcdf/1.11.1.1
+module load cray-hdf5-parallel/1.10.5.2
+module load gcc/8.3.0
+
+> Currently Loaded Modulefiles:
+>   1) slurm/19.05.3-2                    6) cray-libsci/19.06.1               11) craype-ivybridge
+>   2) craype-network-aries               7) pmi/5.0.14                        12) cray-netcdf-hdf5parallel/4.6.3.2
+>   3) craype/2.6.2                       8) atp/2.1.3                         13) cray-parallel-netcdf/1.11.1.1
+>   4) cray-mpich/7.7.10                  9) perftools-base/7.1.1              14) cray-hdf5-parallel/1.10.5.2
+>   5) intel/19.0.5.281                  10) PrgEnv-intel/6.0.5                15) gcc/8.3.0
+
+export CC=cc
+export FC=ftn
+export CXX=cc
+export SRC_DIR=/scratch/ywang/comFV3SAR/testings
+export INSTALL_PREFIX=/scratch/ywang/comFV3SAR/testings/INSTALL
+export CMAKE=/scratch/software/Odin/bin/cmake
+
+mkdir -p $SRC_DIR
+cd $SRC_DIR
+
+git clone -b ufs-v2.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+cd NCEPLIBS-external
+mkdir build && cd build
+# If netCDF is not built, also don't build PNG, because netCDF uses the default (OS) zlib in the search path
+$CMAKE -DBUILD_PNG=OFF -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX -DMPITYPE=mpi -DDEPLOY=ON .. 2>&1 | tee log.cmake
+srun -n 1 make VERBOSE=1 -j8 2>&1 | tee log.make
+
+cd $SRC_DIR
+git clone -b ufs-v2.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
+cd NCEPLIBS
+mkdir build && cd build
+$CMAKE -DEXTERNAL_LIBS_DIR=$INSTALL_PREFIX -DCMAKE_INSTALL_PREFIX=$INSTALL_PREFIX -DOPENMP=ON -DDEPLOY=ON .. 2>&1 | tee log.cmake
+make VERBOSE=1 -j8 2>&1 | tee log.make
+make deploy 2>&1 | tee log.deploy
+cd ..
+# Convert lua modulefiles into tcl modulefiles
+lua2tcl.py $INSTALL_PREFIX/modules
+
+
+- END OF THE SETUP INSTRUCTIONS -
+
+
+The following instructions are for building the ufs-weather-model (standalone;
+not the UFS applications - for the latter, the model is built by the workflow)
+with those libraries installed.
+
+This is separate from NCEPLIBS-external and NCEPLIBS, and details on how to get
+the code are provided here: https://github.com/ufs-community/ufs-weather-model/wiki
+
+$> git clone -b develop --recursive https://github.com/ufs-community/ufs-weather-model
+
+After checking out the code and changing to the top-level directory of ufs-weather-model,
+the following commands should suffice to build the model.
+
+
+module purge
+module load slurm/19.05.3-2
+module load craype/2.6.2
+module load cray-mpich/7.7.10
+module load craype-network-aries
+module load cray-libsci/19.06.1
+module load pmi/5.0.14
+module load PrgEnv-intel/6.0.5
+module swap intel/19.0.5.281
+module load craype-ivybridge
+module load cray-netcdf-hdf5parallel/4.6.3.2
+module load cray-parallel-netcdf/1.11.1.1
+module load cray-hdf5-parallel/1.10.5.2
+module load gcc/8.3.0
+
+export NETCDF=${CRAY_NETCDF_DIR}
+export CMAKE=/scratch/software/Odin/bin/cmake
+export CC=cc
+export FC=ftn
+export CXX=cc
+
+export CMAKE_C_COMPILER=cc
+export CMAKE_CXX_COMPILER=CC
+export CMAKE_Fortran_COMPILER=ftn
+
+module use /scratch/ywang/comFV3SAR/testings/INSTALL/modules
+
+module load esmf/8.0.0
+
+module load bacio/2.4.1
+module load crtm/2.3.0
+module load g2/3.4.1
+module load g2tmpl/1.9.1
+module load ip/3.3.3
+module load nceppost/dceca26
+module load nemsio/2.5.2
+module load sp/2.3.3
+module load w3emc/2.7.3
+module load w3nco/2.4.1
+
+module load gfsio/1.4.1
+module load sfcio/1.4.1
+module load sigio/2.3.2
+
+# In file build.sh, change "cmake" to "$CMAKE" to use cmake version 3.17.3 in the system.
+
+export CMAKE_Platform=odin.intel
+./build.sh 2>&1 | tee build.log

--- a/doc/README_redhat_gnu.txt
+++ b/doc/README_redhat_gnu.txt
@@ -81,8 +81,7 @@ by NCEPLIBS-external as described above.
 cd ${INSTALL_PREFIX}/src
 git clone -b ufs-v2.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
-mkdir build
-cd build
+mkdir build && cd build
 ${INSTALL_PREFIX}/bin/cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} -DCMAKE_PREFIX_PATH=${INSTALL_PREFIX} -DOPENMP=ON .. 2>&1 | tee log.cmake
 make -j8 2>&1 | tee log.make
 

--- a/doc/README_redhat_gnu.txt
+++ b/doc/README_redhat_gnu.txt
@@ -1,10 +1,6 @@
-####################################################################################################
-# TODO: NEEDS UPDATE TO WORK WITH RELEASE/PUBLIC-V2 BRANCHES OF NCEPLIBS-EXTERNAL AND NCEPLIBS     #
-####################################################################################################
+### Red Hat Enterprise Linux 8.2 using gcc-9.2.1 and gfortran-9.2.1
 
-### Red Hat Enterprise Linux 8.1 using gcc-9.2.1 and gfortran-9.2.1
-
-The following instructions were tested on a Red Hat 8 Amazon EC2 compute node, which comes with
+The following instructions were tested on a Red Hat 8.2 Amazon EC2 compute node, which comes with
 essentially no packages installed. Many of the packages that are installed with yum in the
 following may already be installed on your system. Note that the yum Open MPI library did not
 work correctly in our tests, instead the NCEPLIBS-external MPICH version is used.
@@ -39,17 +35,20 @@ yum install m4
 # Install gcc-9.2.1 - does this work w/o installing gcc-8.3.1 above?
 yum install gcc-toolset-9-gcc-c++.x86_64 gcc-toolset-9-gcc-gfortran.x86_64
 
-mkdir /usr/local/ufs-develop
-chown -R ec2-user:ec2-user /usr/local/ufs-develop
+export INSTALL_PREFIX=/usr/local/NCEPLIBS-ufs-v2.0.0
+
+mkdir ${INSTALL_PREFIX}
+chown -R ec2-user:ec2-user ${INSTALL_PREFIX}
 exit
 
 scl enable gcc-toolset-9 bash
 
+export INSTALL_PREFIX=/usr/local/NCEPLIBS-ufs-v2.0.0
 export CC=gcc
 export CXX=g++
 export FC=gfortran
 
-cd /usr/local/ufs-develop
+cd ${INSTALL_PREFIX}
 mkdir src
 
 2.Install missing external libraries from NCEPLIBS-external
@@ -58,19 +57,18 @@ The user is referred to the top-level README.md for more detailed instructions o
 NCEPLIBS-external and configure it (e.g., how to turn off building certain packages such as MPI etc).
 The default configuration assumes that all dependencies are built and installed: MPI, netCDF, ...
 
-cd /usr/local/ufs-develop/src
-git clone -b develop --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+cd ${INSTALL_PREFIX}/src
+git clone -b ufs-v2.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 # Install cmake 3.16.3 (default OS version is too old)
 cd cmake-src
-./bootstrap --prefix=/usr/local/ufs-develop 2>&1 | tee log.bootstrap
+./bootstrap --prefix=${INSTALL_PREFIX} 2>&1 | tee log.bootstrap
 make 2>&1 | tee log.make
 make install 2>&1 | tee log.install
 cd ..
 mkdir build && cd build
-/usr/local/ufs-develop/bin/cmake -DCMAKE_INSTALL_PREFIX=/usr/local/ufs-develop .. 2>&1 | tee log.cmake
+${INSTALL_PREFIX}/bin/cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} .. 2>&1 | tee log.cmake
 make -j8 2>&1 | tee log.make
-# no make install needed
 
 
 3. Install NCEPLIBS
@@ -80,21 +78,20 @@ The user is referred to the top-level README.md of the NCEPLIBS GitHub repositor
 and build NCEPLIBS. The default configuration assumes that all dependencies were built
 by NCEPLIBS-external as described above.
 
-cd /usr/local/ufs-develop/src
-git clone -b develop --recursive https://github.com/NOAA-EMC/NCEPLIBS
+cd ${INSTALL_PREFIX}/src
+git clone -b ufs-v2.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build
 cd build
-/usr/local/ufs-develop/bin/cmake -DCMAKE_INSTALL_PREFIX=/usr/local/ufs-develop -DCMAKE_PREFIX_PATH=/usr/local/ufs-develop .. 2>&1 | tee log.cmake
+${INSTALL_PREFIX}/bin/cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} -DCMAKE_PREFIX_PATH=${INSTALL_PREFIX} -DOPENMP=ON .. 2>&1 | tee log.cmake
 make -j8 2>&1 | tee log.make
-# no make install needed
 
 
 - END OF THE SETUP INSTRUCTIONS -
 
 
 The following instructions are for building the ufs-weather-model (standalone;
-not the ufs-mrweather app - for the latter, the model is built by the workflow)
+not the UFS applications - for the latter, the model is built by the workflow)
 with those libraries installed.
 
 This is separate from NCEPLIBS-external and NCEPLIBS, and details on how to get
@@ -103,17 +100,19 @@ the code are provided here: https://github.com/ufs-community/ufs-weather-model/w
 After checking out the code and changing to the top-level directory of ufs-weather-model,
 the following commands should suffice to build the model.
 
+export INSTALL_PREFIX=/usr/local/NCEPLIBS-ufs-v2.0.0
 
 scl enable gcc-toolset-9 bash
-export CC=gcc
-export CXX=g++
-export FC=gfortran
+export CC=mpicc
+export CXX=mpicxx
+export FC=mpif90
 ulimit -s unlimited
-export PATH=/usr/local/ufs-develop/bin:$PATH
-export LD_LIBRARY_PATH=/usr/local/ufs-develop/lib:/usr/local/ufs-develop/lib64:$PATH
-export NETCDF=/usr/local/ufs-develop
-export ESMFMKFILE=/usr/local/ufs-develop/lib64/esmf.mk
-# DH note: for some reason, this suffices and the system finds all the NCEP libraries;
-# possibly the LD_LIBRARY_PATH makes cmake search for cmake config files in the right place
+
+export PATH=${INSTALL_PREFIX}/bin:$PATH
+export LD_LIBRARY_PATH=${INSTALL_PREFIX}/lib:${INSTALL_PREFIX}/lib64:$PATH
+export NETCDF=${INSTALL_PREFIX}
+export ESMFMKFILE=${INSTALL_PREFIX}/lib64/esmf.mk
+export CMAKE_PREFIX_PATH=${INSTALL_PREFIX}
+
 export CMAKE_Platform=linux.gnu
 ./build.sh 2>&1 | tee build.log

--- a/doc/README_stampede_intel.txt
+++ b/doc/README_stampede_intel.txt
@@ -1,7 +1,3 @@
-####################################################################################################
-# TODO: NEEDS UPDATE TO WORK WITH RELEASE/PUBLIC-V2 BRANCHES OF NCEPLIBS-EXTERNAL AND NCEPLIBS     #
-####################################################################################################
-
 Setup instructions for TACC Stampede using Intel-18.0.2
 
 module purge
@@ -25,37 +21,39 @@ module li
 >   2) git/2.24.1        4) xalt/2.8        6) intel/18.0.2   8) impi/18.0.2   10) pnetcdf/1.11.0
 
 export CC=icc
-export FC=ifort
 export CXX=icpc
+export FC=ifort
 export NETCDF=${TACC_NETCDF_DIR}
 export HDF5_ROOT=/opt/apps/intel18/hdf5/1.10.4/x86_64
 
-mkdir -p $WORK/NCEPLIBS-develop/src
-# $WORK is set automatically by the system; for the user writing these instructions,
-# it corresponds to /work/06146/tg854455/stampede2/NCEPLIBS-develop/src
+# DH* TEMPORARY - NEED SHARED LOCATION
+export INSTALL_PREFIX=/work/06146/tg854455/stampede2/NCEPLIBS-ufs-v2.0.0
+# *DH
 
-cd $WORK/NCEPLIBS-develop/src
-git clone -b develop --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+mkdir -p ${INSTALL_PREFIX}/src
+cd ${INSTALL_PREFIX}/src
+
+git clone -b ufs-v2.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
 # If netCDF is not built, also don't build PNG, because netCDF uses the default (OS) zlib in the search path
-cmake -DBUILD_MPI=OFF -DBUILD_PNG=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=$WORK/NCEPLIBS-develop .. 2>&1 | tee log.cmake
+cmake -DBUILD_PNG=OFF -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} -DDEPLOY=ON .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
 
-cd $WORK/NCEPLIBS-develop/src
-git clone -b develop --recursive https://github.com/NOAA-EMC/NCEPLIBS
+cd ${INSTALL_PREFIX}/src
+git clone -b ufs-v2.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build && cd build
-cmake -DEXTERNAL_LIBS_DIR=$WORK/NCEPLIBS-develop -DCMAKE_INSTALL_PREFIX=$WORK/NCEPLIBS-develop .. 2>&1 | tee log.cmake
+cmake -DCMAKE_PREFIX_PATH=${INSTALL_PREFIX} -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} -DDEPLOY=ON -DOPENMP=ON .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
-make install 2>&1 | tee log.install
+make deploy 2>&1 | tee log.deploy
 
 
 - END OF THE SETUP INSTRUCTIONS -
 
 
 The following instructions are for building the ufs-weather-model (standalone;
-not the ufs-mrweather app - for the latter, the model is built by the workflow)
+not the UFS applications - for the latter, the model is built by the workflow)
 with those libraries installed.
 
 This is separate from NCEPLIBS-external and NCEPLIBS, and details on how to get
@@ -64,15 +62,13 @@ the code are provided here: https://github.com/ufs-community/ufs-weather-model/w
 After checking out the code and changing to the top-level directory of ufs-weather-model,
 the following commands should suffice to build the model.
 
-
 module purge
-#
 module load libfabric/1.7.0
 module load git/2.24.1
 module load autotools/1.1
 module load xalt/2.8
 module load TACC
-#
+
 module load python3/3.7.0
 module load intel/18.0.2
 module load cmake/3.16.1
@@ -81,10 +77,31 @@ module load pnetcdf/1.11.0
 module load netcdf/4.6.2
 
 export CC=icc
-export FC=ifort
 export CXX=icpc
+export FC=ifort
 export NETCDF=${TACC_NETCDF_DIR}
 
-. $WORK/NCEPLIBS-develop/bin/setenv_nceplibs.sh
+module use /work/06146/tg854455/stampede2/NCEPLIBS-ufs-v2.0.0/modules
+
+module load esmf/8.0.0
+
+module load bacio/2.4.1
+module load crtm/2.3.0
+module load g2/3.4.1
+module load g2tmpl/1.9.1
+module load ip/3.3.3
+module load nceppost/dceca26
+module load nemsio/2.5.2
+module load sp/2.3.3
+module load w3emc/2.7.3
+module load w3nco/2.4.1
+
+module load gfsio/1.4.1
+module load sfcio/1.4.1
+module load sigio/2.3.2
+
+export CMAKE_C_COMPILER=mpiicc
+export CMAKE_CXX_COMPILER=mpiicpc
+export CMAKE_Fortran_COMPILER=mpiifort
 export CMAKE_Platform=stampede.intel
 ./build.sh 2>&1 | tee build.log

--- a/doc/README_stampede_intel.txt
+++ b/doc/README_stampede_intel.txt
@@ -27,7 +27,7 @@ export NETCDF=${TACC_NETCDF_DIR}
 export HDF5_ROOT=/opt/apps/intel18/hdf5/1.10.4/x86_64
 
 # DH* TEMPORARY - NEED SHARED LOCATION
-export INSTALL_PREFIX=/work/06146/tg854455/stampede2/NCEPLIBS-ufs-v2.0.0
+export INSTALL_PREFIX=/work/06146/tg854455/stampede2/NCEPLIBS-ufs-v2.0.0/intel-18.0.2/impi-18.0.2
 # *DH
 
 mkdir -p ${INSTALL_PREFIX}/src
@@ -81,7 +81,7 @@ export CXX=icpc
 export FC=ifort
 export NETCDF=${TACC_NETCDF_DIR}
 
-module use /work/06146/tg854455/stampede2/NCEPLIBS-ufs-v2.0.0/modules
+module use /work/06146/tg854455/stampede2/NCEPLIBS-ufs-v2.0.0/intel-18.0.2/impi-18.0.2/modules
 
 module load esmf/8.0.0
 

--- a/doc/README_ubuntu_gnu.txt
+++ b/doc/README_ubuntu_gnu.txt
@@ -1,10 +1,6 @@
-####################################################################################################
-# TODO: NEEDS UPDATE TO WORK WITH RELEASE/PUBLIC-V2 BRANCHES OF NCEPLIBS-EXTERNAL AND NCEPLIBS     #
-####################################################################################################
+### Ubuntu Linux 20.04 LTS using gcc-9.3.0 and gfortran-9.3.0
 
-### Ubuntu Linux 20.04 LTS using gcc-8.3.0 and gfortran-8.3.0
-
-The following instructions were tested on a Ubuntu 18.04 Amazon EC2 compute node, which comes with
+The following instructions were tested on a Ubuntu 20.04 Amazon EC2 compute node, which comes with
 essentially no packages installed. Many of the packages that are installed with apt in the
 following may already be installed on your system. Note that the apt Open MPI library did not
 work correctly in our tests, instead the NCEPLIBS-external MPICH version is used.
@@ -41,15 +37,18 @@ apt install -y gfortran-9 g++-9
 # Install cmake-3.16.3
 apt install -y cmake
 
-mkdir /usr/local/ufs-develop
-chown -R ubuntu:ubuntu /usr/local/ufs-develop
+export INSTALL_PREFIX=/usr/local/NCEPLIBS-ufs-v2.0.0
+
+mkdir ${INSTALL_PREFIX}
+chown -R ubuntu:ubuntu ${INSTALL_PREFIX}
 exit
 
 export CC=gcc-9
 export CXX=g++-9
 export FC=gfortran-9
+export INSTALL_PREFIX=/usr/local/NCEPLIBS-ufs-v2.0.0
 
-cd /usr/local/ufs-develop
+cd ${INSTALL_PREFIX}
 mkdir src
 
 2.Install missing external libraries from NCEPLIBS-external
@@ -58,13 +57,12 @@ The user is referred to the top-level README.md for more detailed instructions o
 NCEPLIBS-external and configure it (e.g., how to turn off building certain packages such as MPI etc).
 The default configuration assumes that all dependencies are built and installed: MPI, netCDF, ...
 
-cd /usr/local/ufs-develop/src
-git clone -b develop --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
+cd ${INSTALL_PREFIX}/src
+git clone -b ufs-v2.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
-cmake -DCMAKE_INSTALL_PREFIX=/usr/local/ufs-develop .. 2>&1 | tee log.cmake
+cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} .. 2>&1 | tee log.cmake
 make -j8 2>&1 | tee log.make
-# no make install needed
 
 
 3. Install NCEPLIBS
@@ -74,21 +72,19 @@ The user is referred to the top-level README.md of the NCEPLIBS GitHub repositor
 and build NCEPLIBS. The default configuration assumes that all dependencies were built
 by NCEPLIBS-external as described above.
 
-cd /usr/local/ufs-develop/src
-git clone -b develop --recursive https://github.com/NOAA-EMC/NCEPLIBS
+cd ${INSTALL_PREFIX}/src
+git clone -b ufs-v2.0.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
-mkdir build
-cd build
-cmake -DCMAKE_INSTALL_PREFIX=/usr/local/ufs-develop -DCMAKE_PREFIX_PATH=/usr/local/ufs-develop .. 2>&1 | tee log.cmake
+mkdir build && cd build
+cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} -DCMAKE_PREFIX_PATH=${INSTALL_PREFIX} -DOPENMP=ON .. 2>&1 | tee log.cmake
 make -j8 2>&1 | tee log.make
-# no make install needed
 
 
 - END OF THE SETUP INSTRUCTIONS -
 
 
 The following instructions are for building the ufs-weather-model (standalone;
-not the ufs-mrweather app - for the latter, the model is built by the workflow)
+not the UFS applications - for the latter, the model is built by the workflow)
 with those libraries installed.
 
 This is separate from NCEPLIBS-external and NCEPLIBS, and details on how to get
@@ -97,16 +93,19 @@ the code are provided here: https://github.com/ufs-community/ufs-weather-model/w
 After checking out the code and changing to the top-level directory of ufs-weather-model,
 the following commands should suffice to build the model.
 
+export INSTALL_PREFIX=/usr/local/NCEPLIBS-ufs-v2.0.0
 
-export CC=gcc-9
-export CXX=g++-9
-export FC=gfortran-9
+export CC=mpicc
+export CXX=mpicxx
+export FC=mpif90
+
 ulimit -s unlimited
-export PATH=/usr/local/ufs-develop/bin:$PATH
-export LD_LIBRARY_PATH=/usr/local/ufs-develop/lib:$PATH
-export NETCDF=/usr/local/ufs-develop
-export ESMFMKFILE=/usr/local/ufs-develop/lib/esmf.mk
-# DH note: for some reason, this suffices and the system finds all the NCEP libraries;
-# possibly the LD_LIBRARY_PATH makes cmake search for cmake config files in the right place
+
+export PATH=${INSTALL_PREFIX}/bin:$PATH
+export LD_LIBRARY_PATH=${INSTALL_PREFIX}/lib:$PATH
+export NETCDF=${INSTALL_PREFIX}
+export ESMFMKFILE=${INSTALL_PREFIX}/lib/esmf.mk
+export CMAKE_PREFIX_PATH=${INSTALL_PREFIX}
+
 export CMAKE_Platform=linux.gnu
 ./build.sh 2>&1 | tee build.log


### PR DESCRIPTION
This PR updates the documentation for all remaining platforms and add instructions for odin.intel and for docker (initial version).

Further changes for docker are expected in a future PR, possibly also minor updates of the odin.intel instructions. All other instructions have been tested to work and should be final.