### PR TITLE
release/public-v1: downgrade Intel compiler versions 19.x.y to 18.m.n on cheyenne, gaea, orion

### DIFF
--- a/doc/README_cheyenne_intel.txt
+++ b/doc/README_cheyenne_intel.txt
@@ -1,8 +1,8 @@
-Setup instructions for CISL Cheyenne using Intel-19.0.5
+Setup instructions for CISL Cheyenne using Intel-18.0.5
 
 module purge
 module load ncarenv/1.3
-module load intel/19.0.5
+module load intel/18.0.5
 module load ncarcompilers/0.5.0
 module load netcdf/4.7.3
 module load mpt/2.19
@@ -10,28 +10,28 @@ module load cmake/3.16.4
 module li
 
 > Currently Loaded Modules:
->  1) ncarenv/1.3   2) intel/19.0.5   3) ncarcompilers/0.5.0   4) mpt/2.19   5) netcdf/4.7.3   6) cmake/3.16.4
+>  1) ncarenv/1.3   2) intel/18.0.5   3) ncarcompilers/0.5.0   4) mpt/2.19   5) netcdf/4.7.3   6) cmake/3.16.4
 
 export CC=mpicc
 export FC=mpif90
 export CXX=mpicxx
 
-mkdir -p /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.1.0/intel-19.0.5/mpt-2.19/src
-cd /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.1.0/intel-19.0.5/mpt-2.19/src
+mkdir -p /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.1.0/intel-18.0.5/mpt-2.19/src
+cd /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.1.0/intel-18.0.5/mpt-2.19/src
 
 git clone -b ufs-v1.1.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
-cmake -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DBUILD_PNG=OFF -DCMAKE_INSTALL_PREFIX=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.1.0/intel-19.0.5/mpt-2.19 .. 2>&1 | tee log.cmake
+cmake -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DBUILD_PNG=OFF -DCMAKE_INSTALL_PREFIX=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.1.0/intel-18.0.5/mpt-2.19 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j2 2>&1 | tee log.make
 
-cd /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.1.0/intel-19.0.5/mpt-2.19/src/
+cd /glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.1.0/intel-18.0.5/mpt-2.19/src/
 git clone -b ufs-v1.1.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build && cd build
-cmake -DEXTERNAL_LIBS_DIR=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.1.0/intel-19.0.5/mpt-2.19 -DCMAKE_INSTALL_PREFIX=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.1.0/intel-19.0.5/mpt-2.19 .. 2>&1 | tee log.cmake
+cmake -DEXTERNAL_LIBS_DIR=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.1.0/intel-18.0.5/mpt-2.19 -DCMAKE_INSTALL_PREFIX=/glade/p/ral/jntp/GMTB/tools/NCEPLIBS-ufs-v1.1.0/intel-18.0.5/mpt-2.19 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j2 2>&1 | tee log.make
-make install
+make install 2>&1 | tee log.install
 
 
 - END OF THE SETUP INSTRUCTIONS -
@@ -50,7 +50,7 @@ the following commands should suffice to build the model.
 
 module purge
 module load ncarenv/1.3
-module load intel/19.0.5
+module load intel/18.0.5
 module load ncarcompilers/0.5.0
 module load netcdf/4.7.3
 module load mpt/2.19
@@ -60,7 +60,7 @@ export CC=mpicc
 export FC=mpif90
 export CXX=mpicxx
 
-module use -a /glade/p/ral/jntp/GMTB/tools/modulefiles/intel-19.0.5/mpt-2.19
+module use -a /glade/p/ral/jntp/GMTB/tools/modulefiles/intel-18.0.5/mpt-2.19
 module load NCEPlibs/1.1.0
 
 export CMAKE_Platform=cheyenne.intel

--- a/doc/README_gaea_intel.txt
+++ b/doc/README_gaea_intel.txt
@@ -1,6 +1,7 @@
-Setup instructions for NOAA RDHPC Gaea using Cray Intel-19.0.5.281
+Setup instructions for NOAA RDHPC Gaea using Cray Intel-18.0.6.288
 
-module load intel/19.0.5.281
+module unload intel
+module load intel/18.0.6.288
 module unload cray-mpich
 module load cray-mpich/7.7.11
 module unload cray-netcdf
@@ -10,7 +11,7 @@ module li
 > Currently Loaded Modulefiles:
 >   1) modules/3.2.11.4                                 7) udreg/2.3.2-7.0.2.1_2.15__g8175d3d.ari          13) job/2.2.4-7.0.2.1_2.18__g36b56f4.ari            19) PrgEnv-intel/6.0.5                              25) darshan/3.2.1
 >   2) eproxy/2.0.24-7.0.2.1_2.20__g8e04b33.ari         8) ugni/6.0.14.0-7.0.2.1_3.15__ge78e5b0.ari        14) dvs/2.12_2.2.164-7.0.2.1_3.8__g1afc88eb         20) craype-broadwell                                26) DefApps
->   3) intel/19.0.5.281                                 9) pmi/5.0.15                                      15) alps/6.6.59-7.0.2.1_3.7__g872a8d62.ari          21) cray-mpich/7.7.11                               27) hpcrpt/noaa-3
+>   3) intel/18.0.6.288                                 9) pmi/5.0.15                                      15) alps/6.6.59-7.0.2.1_3.7__g872a8d62.ari          21) cray-mpich/7.7.11                               27) hpcrpt/noaa-3
 >   4) craype-network-aries                            10) dmapp/7.1.1-7.0.2.1_2.19__g38cf134.ari          16) rca/2.2.20-7.0.2.1_2.20__g8e3fb5b.ari           22) CmrsEnv                                         28) cmake/3.17.0
 >   5) craype/2.6.3                                    11) gni-headers/5.0.12.0-7.0.2.1_2.4__g3b1768f.ari  17) atp/2.1.3                                       23) TimeZoneEDT
 >   6) cray-libsci/19.06.1                             12) xpmem/2.2.20-7.0.2.1_2.15__g87eb960.ari         18) perftools-base/7.1.3                            24) globus-toolkit/6.0.17
@@ -21,23 +22,23 @@ export FC=ftn
 export CXX=CC
 export MPI_ROOT=/opt/cray/pe/mpt/7.7.11/gni/mpich-intel/16.0
 
-mkdir -p /lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.1.0/intel-19.0.5.281/cray-mpich-7.7.11/src
+mkdir -p /lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.1.0/intel-18.0.6.288/cray-mpich-7.7.11/src
 
-cd /lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.1.0/intel-19.0.5.281/cray-mpich-7.7.11/src
+cd /lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.1.0/intel-18.0.6.288/cray-mpich-7.7.11/src
 # Note: remote access severely limited on gaea; need to do the git clone on a remote system and rsync to gaea
 git clone -b ufs-v1.1.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
-cmake -DBUILD_MPI=OFF -DCMAKE_INSTALL_PREFIX=/lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.1.0/intel-19.0.5.281/cray-mpich-7.7.11 .. 2>&1 | tee log.cmake
+cmake -DBUILD_MPI=OFF -DCMAKE_INSTALL_PREFIX=/lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.1.0/intel-18.0.6.288/cray-mpich-7.7.11 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
 # no make install necessary
 
-cd /lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.1.0/intel-19.0.5.281/cray-mpich-7.7.11/src
+cd /lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.1.0/intel-18.0.6.288/cray-mpich-7.7.11/src
 # Note: remote access severely limited on gaea; need to do the git clone on a remote system and rsync to gaea
 git clone -b ufs-v1.1.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build && cd build
-cmake -DEXTERNAL_LIBS_DIR=/lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.1.0/intel-19.0.5.281/cray-mpich-7.7.11 -DCMAKE_INSTALL_PREFIX=/lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.1.0/intel-19.0.5.281/cray-mpich-7.7.11 .. 2>&1 | tee log.cmake
+cmake -DEXTERNAL_LIBS_DIR=/lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.1.0/intel-18.0.6.288/cray-mpich-7.7.11 -DCMAKE_INSTALL_PREFIX=/lustre/f2/pdata/esrl/gsd/ufs/modules/NCEPlibs-ufs-v1.1.0/intel-18.0.6.288/cray-mpich-7.7.11 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
 make install VERBOSE=1 2>&1 | tee log.install
 
@@ -56,14 +57,14 @@ After checking out the code and changing to the top-level directory of ufs-weath
 the following commands should suffice to build the model.
 
 
-module load intel/19.0.5.281
+module load intel/18.0.6.288
 module unload cray-mpich
 module load cray-mpich/7.7.11
 module unload cray-netcdf
 module load cmake/3.17.0
 module li
 
-module use -a /lustre/f2/pdata/esrl/gsd/ufs/modules/modulefiles/intel-19.0.5.281/cray-mpich-7.7.11
+module use -a /lustre/f2/pdata/esrl/gsd/ufs/modules/modulefiles/intel-18.0.6.288/cray-mpich-7.7.11
 module load NCEPlibs/1.1.0
 
 export CMAKE_Platform=gaea.intel

--- a/doc/README_orion_intel.txt
+++ b/doc/README_orion_intel.txt
@@ -1,14 +1,14 @@
-Setup instructions for MSU Orion using Intel-19.1.0.166
+Setup instructions for MSU Orion using Intel-18.0.5.274
 
 module purge
-module load intel/2020
-module load impi/2020
+module load intel/2018.4
+module load impi/2018.4
 module load netcdf/4.7.2
 module load cmake/3.15.4
 module li
 
 > Currently Loaded Modules:
-  1) intel/2020   2) munge/0.5.13   3) slurm/19.05.3-2   4) impi/2020   5) hdf5/1.10.5   6) netcdf/4.7.2   7) cmake/3.15.4
+  1) munge/0.5.13   2) slurm/19.05.3-2   3) impi/2018.4   4) intel/2018.4   5) hdf5/1.10.5   6) netcdf/4.7.2   7) cmake/3.15.4
 
 # Note: HDF5 is in: /apps/hdf5/1.10.5/intel/18.0.5.274
 # Note: ZLIB and PNG are in: /usr/include, /usr/lib64/
@@ -23,21 +23,21 @@ export PNG_ROOT=/usr
 # Set environment variable WORK to a directory in your userspace, example for user dheinzel of group gmtb:
 #export WORK=/work/noaa/gmtb/dheinzel
 
-mkdir -p $WORK/NCEPLIBS-ufs-v1.1.0/intel-19.1.0.166/impi-2020.0.166/src
-cd $WORK/NCEPLIBS-ufs-v1.1.0/intel-19.1.0.166/impi-2020.0.166/src
+mkdir -p $WORK/NCEPLIBS-ufs-v1.1.0/intel-18.0.5.274/impi-2018.5.274/src
+cd $WORK/NCEPLIBS-ufs-v1.1.0/intel-18.0.5.274/impi-2018.5.274/src
 
 git clone -b ufs-v1.1.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS-external
 cd NCEPLIBS-external
 mkdir build && cd build
 # If netCDF is not built, also don't build PNG, because netCDF uses the default (OS) zlib in the search path
-cmake -DBUILD_PNG=OFF -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=$WORK/NCEPLIBS-ufs-v1.1.0/intel-19.1.0.166/impi-2020.0.166 .. 2>&1 | tee log.cmake
+cmake -DBUILD_PNG=OFF -DBUILD_MPI=OFF -DBUILD_NETCDF=OFF -DCMAKE_INSTALL_PREFIX=$WORK/NCEPLIBS-ufs-v1.1.0/intel-18.0.5.274/impi-2018.5.274 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
 
-cd $WORK/NCEPLIBS-ufs-v1.1.0/intel-19.1.0.166/impi-2020.0.166/src
+cd $WORK/NCEPLIBS-ufs-v1.1.0/intel-18.0.5.274/impi-2018.5.274/src
 git clone -b ufs-v1.1.0 --recursive https://github.com/NOAA-EMC/NCEPLIBS
 cd NCEPLIBS
 mkdir build && cd build
-cmake -DEXTERNAL_LIBS_DIR=$WORK/NCEPLIBS-ufs-v1.1.0/intel-19.1.0.166/impi-2020.0.166 -DCMAKE_INSTALL_PREFIX=$WORK/NCEPLIBS-ufs-v1.1.0/intel-19.1.0.166/impi-2020.0.166 .. 2>&1 | tee log.cmake
+cmake -DEXTERNAL_LIBS_DIR=$WORK/NCEPLIBS-ufs-v1.1.0/intel-18.0.5.274/impi-2018.5.274 -DCMAKE_INSTALL_PREFIX=$WORK/NCEPLIBS-ufs-v1.1.0/intel-18.0.5.274/impi-2018.5.274 .. 2>&1 | tee log.cmake
 make VERBOSE=1 -j8 2>&1 | tee log.make
 make install 2>&1 | tee log.install
 
@@ -57,8 +57,8 @@ the following commands should suffice to build the model.
 
 
 module purge
-module load intel/2020
-module load impi/2020
+module load intel/2018.4
+module load impi/2018.4
 module load netcdf/4.7.2
 module load cmake/3.15.4
 module li
@@ -69,7 +69,7 @@ export CMAKE_C_COMPILER=mpiicc
 export CMAKE_CXX_COMPILER=mpiicpc
 export CMAKE_Fortran_COMPILER=mpiifort
 
-. $WORK/NCEPLIBS-ufs-v1.1.0/intel-19.1.0.166/impi-2020.0.166/bin/setenv_nceplibs.sh
+. $WORK/NCEPLIBS-ufs-v1.1.0/intel-18.0.5.274/impi-2018.5.274/bin/setenv_nceplibs.sh
 export CMAKE_Platform=orion.intel
 cp cmake/configure_hera.intel.cmake cmake/configure_orion.intel.cmake
 ./build.sh 2>&1 | tee build.log


### PR DESCRIPTION
Documentation change only, no testing or reinstall required.

This PR updates the documentation to use Intel 18.x.y instead of Intel 19.m.n as this seems to address issues with `chgres_cube.exe` on Cheyenen, Gaea and Orion. See https://github.com/ufs-community/ufs-mrweather-app/issues/190 for more information.

After merging this PR, tag ufs-v1.1.0 must be updated.