### PR TITLE
tmplModulefiles/netcdf: add the install bin directory to PATH, required for SRW App workflow

### DIFF
--- a/tmplModulefiles/netcdf
+++ b/tmplModulefiles/netcdf
@@ -9,3 +9,4 @@ conflict netcdf
 
 # Set environment variables
 setenv NETCDF ${CMAKE_INSTALL_PREFIX}
+prepend-path PATH ${CMAKE_INSTALL_PREFIX}/bin


### PR DESCRIPTION
As the title says. Required for SRW App workflow (needs `ncdump`). This has been tested on gaea.intel (fresh install), the existing modulefiles on other platforms have been updated manually. See https://docs.google.com/spreadsheets/d/1JLx0ge6DDpbmoFDuuSFSZHgbd5xcN3JmP98v0qpyetQ/edit#gid=0.