### PR TITLE
release/public-v2: final documentation updates for the SRW App release 1.0.0

### DIFF
--- a/.github/workflows/macos-clanggfortran.yml
+++ b/.github/workflows/macos-clanggfortran.yml
@@ -18,6 +18,8 @@ jobs:
         /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
         # mpich installs gcc@10 as prerequisite
         brew install automake coreutils gnu-sed mpich llvm@9
+        # mpif90 is looking for "gfortran" only
+        ln -sf /usr/local/bin/gfortran-10 /usr/local/bin/gfortran
 
     - name: Checkout
       uses: actions/checkout@v2

--- a/.github/workflows/macos-gccgfortran.yml
+++ b/.github/workflows/macos-gccgfortran.yml
@@ -18,6 +18,8 @@ jobs:
         /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
         # mpich installs gcc@10 as prerequisite
         brew install automake coreutils gnu-sed mpich
+        # mpif90 is looking for "gfortran" only
+        ln -sf /usr/local/bin/gfortran-10 /usr/local/bin/gfortran
 
     - name: Checkout
       uses: actions/checkout@v2

--- a/doc/README_macos_clanggfortran.txt
+++ b/doc/README_macos_clanggfortran.txt
@@ -116,3 +116,22 @@ export CMAKE_Platform=macosx.gnu
 
 Note. OpenMP support is currently broken with the clang compiler. The UFS models should
 detect that the clang compiler is used and turn off threading when building the model.
+
+
+4. Install Python packages for the UFS SRW Application (regional workflow, plotting)
+
+The suggested approach is to install the Python miniconda3 distribution and the necessary Python modules. It is possible to skip the automatic conda initialization in `.bash_profile` and instead run the conda init command by hand or create a script to source.
+
+wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+sh Miniconda3-latest-Linux-x86_64.sh
+# init conda or create script to source that contains the following line, unless conda init is added to .bash_profile
+eval "$(/path/to/your/conda/installation/bin/conda shell.bash hook)"
+conda create --name regional_workflow
+conda activate regional_workflow
+conda install -c conda-forge f90nml
+conda install jinja2
+conda install pyyaml
+conda install cartopy
+conda install matplotlib
+conda install scipy
+conda install -c conda-forge pygrib

--- a/doc/README_macos_gccgfortran.txt
+++ b/doc/README_macos_gccgfortran.txt
@@ -100,3 +100,21 @@ ulimit -S -s unlimited
 export CMAKE_Platform=macosx.gnu
 ./build.sh 2>&1 | tee build.log
 
+
+4. Install Python packages for the UFS SRW Application (regional workflow, plotting)
+
+The suggested approach is to install the Python miniconda3 distribution and the necessary Python modules. It is possible to skip the automatic conda initialization in `.bash_profile` and instead run the conda init command by hand or create a script to source.
+
+wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+sh Miniconda3-latest-Linux-x86_64.sh
+# init conda or create script to source that contains the following line, unless conda init is added to .bash_profile
+eval "$(/path/to/your/conda/installation/bin/conda shell.bash hook)"
+conda create --name regional_workflow
+conda activate regional_workflow
+conda install -c conda-forge f90nml
+conda install jinja2
+conda install pyyaml
+conda install cartopy
+conda install matplotlib
+conda install scipy
+conda install -c conda-forge pygrib

--- a/doc/README_redhat_gnu.txt
+++ b/doc/README_redhat_gnu.txt
@@ -7,11 +7,13 @@ work correctly in our tests, instead the NCEPLIBS-external MPICH version is used
 
 AMI: RHEL-8.2.0_HVM-20200423-x86_64-0-Hourly2-GP2 (ami-098f16afa9edf40be)
 
-Instance: t2.xlarge instance with 4 cores and 16GB of memory was used, 100GB EBS
+Instance: t2.2xlarge instance with 8 cores and 32GB of memory was used, 100GB EBS
 
 1. Install the GNU compilers and other utilities
 
 sudo su
+# Add epel repository
+yum install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 # Optional: this is usually a good idea, but should be used with care (it may destroy your existing setup)
 yum update
 # Install wget-1.19.5
@@ -25,13 +27,23 @@ yum install -y openssl-devel
 # Install patch-2.7.6
 yum install -y patch
 # Install Python-3.8.0
-yum install -y python38
+yum install -y python38 python38-devel
 alternatives --config python
 # choose /usr/bin/python3
+# Install python38-pip-wheel-19.3.1
+yum install python38-pip-wheel
 # Install libxml2-2.9.7 (for xmllint)
 yum install libxml2
 # Install m4-1.4.18
 yum install m4
+# Install time-1.9
+yum install time
+# Install bc-1.07.1
+yum install bc
+# Install proj- 6.3.2
+yum install proj-devel
+# Install geos-3.7.2
+yum install geos-devel
 # Install gcc-9.2.1 - does this work w/o installing gcc-8.3.1 above?
 yum install gcc-toolset-9-gcc-c++.x86_64 gcc-toolset-9-gcc-gfortran.x86_64
 
@@ -108,3 +120,25 @@ ulimit -s unlimited
 
 export CMAKE_Platform=linux.gnu
 ./build.sh 2>&1 | tee build.log
+
+
+4. Install Python packages for the UFS SRW Application (regional workflow, plotting)
+
+sudo su
+scl enable gcc-toolset-9 bash
+export CC=gcc
+export CXX=g++
+export FC=gfortran
+
+pip3 install f90nml
+pip3 install pyyaml
+pip3 install jinja2
+pip3 install pygrib
+pip3 install cartopy
+pip3 install matplotlib
+pip3 install scipy
+
+# Fix incompatible shapely version
+pip3 uninstall shapely
+pip3 install shapely --no-binary shapely
+exit

--- a/doc/README_ubuntu_gnu.txt
+++ b/doc/README_ubuntu_gnu.txt
@@ -7,7 +7,7 @@ work correctly in our tests, instead the NCEPLIBS-external MPICH version is used
 
 AMI: ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200729 (ami-0758470213bdd23b1)
 
-Instance: t2.xlarge instance with 4 cores and 16GB of memory was used, 100GB EBS
+Instance: t2.2xlarge instance with 8 cores and 32GB of memory was used, 100GB EBS
 
 1. Install the GNU compilers and other utilities
 
@@ -26,6 +26,8 @@ apt install -y libssl-dev
 apt install -y patch
 # Configure Python 3.8 as default
 update-alternatives --install /usr/bin/python python /usr/bin/python3.8 1
+# Install pip3-20.0.2
+apt install python3-pip
 # Install libxml2-utils-2.9.10 (for xmllint)
 apt install -y libxml2-utils
 # Install pkg-config-0.29.1
@@ -36,6 +38,12 @@ apt install m4
 apt install -y gfortran-9 g++-9
 # Install cmake-3.16.3
 apt install -y cmake
+# Install unzip-6.0-25
+apt install unzip
+# Install geos-3.8.0
+apt install libgeos-dev
+# Install proj-6.3.1
+apt install libproj-dev
 
 export INSTALL_PREFIX=/usr/local/NCEPLIBS-ufs-v2.0.0
 
@@ -46,7 +54,6 @@ exit
 export CC=gcc-9
 export CXX=g++-9
 export FC=gfortran-9
-export INSTALL_PREFIX=/usr/local/NCEPLIBS-ufs-v2.0.0
 
 cd ${INSTALL_PREFIX}
 mkdir src
@@ -102,3 +109,16 @@ ulimit -s unlimited
 
 export CMAKE_Platform=linux.gnu
 ./build.sh 2>&1 | tee build.log
+
+
+4. Install Python packages for the UFS SRW Application (regional workflow, plotting)
+
+sudo su
+pip3 install f90nml
+pip3 install pyyaml
+pip3 install jinja2
+pip3 install pygrib
+pip3 install cartopy
+pip3 install matplotlib
+pip3 install scipy
+exit


### PR DESCRIPTION
This PR contains
- updates for the install instructions for macOS, Ubuntu and Redhat to include all Python modules required to use the plotting scripts
- updates for Docker/Ubuntu with GNU from @SamuelTrahanNOAA
- fix Travis CI tests on macOS (as time goes by this always stops working)